### PR TITLE
Sync Labels

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,0 +1,71 @@
+
+# Default GitHub labels
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: We are looking for community help
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
+  name: wontfix
+  description: The issue is expected and will not be fixed
+# Languages
+- color: cd00ff
+  name: tofu
+  description: Pull requests that update Tofu/Terraform code
+- color: 00ff44
+  name: shell
+  description: Pull requests that update Shell code
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
+# Components
+- color: ff0073
+  name: git_hooks
+  description: Pull requests that update git hooks
+- color: f27100
+  name: checker
+  description: Pull requests that update checker code
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new configuration file for GitHub labels to the repository. The file defines a set of default labels, language-specific labels, component-specific labels, and size-based labels.

### GitHub labels configuration:

* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR1-R71): Added a new configuration file to define default GitHub labels such as `bug`, `documentation`, `dependencies`, and more.
* Added language-specific labels including `tofu`, `shell`, `just`, and `markdown`.
* Added component-specific labels such as `git_hooks` and `checker`.
* Added size-based labels ranging from `size/XS` to `size/XXL` to categorize pull requests by their size.