### PR TITLE
Add Dependency Review

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,6 +11,7 @@ permissions: {}
 
 jobs:
   configure-labels:
+    name: Configure Labels
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,3 +27,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           manifest: .github/other-configurations/labels.yml
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4.5.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflow configuration to add a new job for dependency review and improve the naming of an existing job.

Improvements to GitHub Actions workflow:

* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6R14): Added a name to the `configure-labels` job for better clarity.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6R30-R37): Added a new `dependency-review` job that checks out the repository and performs a dependency review using the `actions/dependency-review-action` action.