### PR TITLE
Add JackPlowman Repository

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -31,6 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
+          VALIDATE_TERRAFORM_TERRASCAN: false
 
   check-markdown-links:
     name: Check Markdown links

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,37 @@
-.terraform
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.4.0"
+  constraints = "6.4.0"
+  hashes = [
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
+    "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
+    "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
+    "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
+    "zh:402ecaa5add568a52ee01d816810f3b90f693be35c680fcdc9b6284bf55326f1",
+    "zh:60e3bdd9fbefb3c1d790bc08889c1dc0e83636b82284faaa709411aa4f96bb9f",
+    "zh:625099eeff2f8aaecd22a24a451b326828435c8f9de86f2e5e99872e7b467fa7",
+    "zh:79e8b665421009df2260f50e10da1f7a7863b557ece96e2b07dfd2fad1e86fcd",
+    "zh:98e471fefc93dcfedeec750c694110db7d3331dc3a256191d30b9d2f70d12157",
+    "zh:a17702765e1fa92d1c288ddfd97075819ad61b344b341be7e09c554c841a6d9e",
+    "zh:ca72ccf40624ae26bf4660d8dd84a51638f0a1e78d5f19fdfaafaef97f838af6",
+    "zh:d009ab5527d45c44c424d26cd2eb51a5a6a6448f3fb1023b675789588cc08d64",
+    "zh:e5811be1e942a75b14dfcd3e03523d8df60cfbde0d7e24d75e78480a02a58949",
+    "zh:e6008ad28225ad6996b06bcd7f3070863329df406a56754e7fb9c31d6301ace4",
+    "zh:f1d93f56ea4f87183a5de4780704907605851d95a2d285a9ec755bf784c5569c",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/JackPlowman.tf
+++ b/JackPlowman.tf
@@ -1,6 +1,6 @@
 resource "github_repository" "JackPlowman" {
   #checkov:skip=CKV_GIT_1
-  #checkov:skip=CKV_GIT_2
+  #checkov:skip=CKV2_GIT_1
   name        = "JackPlowman"
   description = "My Profile"
   visibility  = "public"

--- a/JackPlowman.tf
+++ b/JackPlowman.tf
@@ -1,6 +1,6 @@
-#checkov:skip=CKV_GIT_1
-#checkov:skip=CKV_GIT_2
 resource "github_repository" "JackPlowman" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV_GIT_2
   name        = "JackPlowman"
   description = "My Profile"
   visibility  = "public"

--- a/JackPlowman.tf
+++ b/JackPlowman.tf
@@ -1,0 +1,15 @@
+resource "github_repository" "JackPlowman" {
+  name        = "JackPlowman"
+  description = "My Profile"
+  visibility  = "public"
+
+  allow_auto_merge       = true
+  allow_merge_commit     = false
+  allow_rebase_merge     = false
+  allow_update_branch    = true
+  delete_branch_on_merge = true
+
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+  vulnerability_alerts        = true
+}

--- a/JackPlowman.tf
+++ b/JackPlowman.tf
@@ -1,3 +1,5 @@
+#checkov:skip=CKV_GIT_1
+#checkov:skip=CKV_GIT_2
 resource "github_repository" "JackPlowman" {
   name        = "JackPlowman"
   description = "My Profile"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.8.7"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.4.0"
+    }
+  }
+  backend "local" {
+    path = "../RepoOrchestratorState/terraform.tfstate"
+  }
+}
+
+provider "github" {
+  token = var.GITHUB_TOKEN
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,3 @@
+variable "GITHUB_TOKEN" {
+  description = "The GitHub token to use for authentication."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,5 @@
 variable "GITHUB_TOKEN" {
   description = "The GitHub token to use for authentication."
+  type        = string
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,4 @@
 variable "GITHUB_TOKEN" {
   description = "The GitHub token to use for authentication."
+  sensitive   = true
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several changes to configure and manage a GitHub repository using Terraform. The changes include adding a new provider, defining a repository resource, setting up the Terraform configuration, and adding a variable for the GitHub token.

Key changes:

### Provider Configuration:
* Added a new provider configuration for `registry.opentofu.org/integrations/github` with version `6.4.0` in the `.terraform.lock.hcl` file.

### Repository Resource:
* Defined a new `github_repository` resource named `JackPlowman` in `JackPlowman.tf`, including settings for visibility, merge options, and vulnerability alerts.

### Terraform Configuration:
* Added the main Terraform configuration in `terraform.tf`, specifying the required version, providers, and backend settings.

### Variables:
* Introduced a new variable `GITHUB_TOKEN` in `variables.tf` for GitHub authentication.
