### PR TITLE
Add RepoOrchestrator Repository Rules

### DIFF
--- a/RepoOrchestrator.tf
+++ b/RepoOrchestrator.tf
@@ -18,3 +18,68 @@ resource "github_repository" "RepoOrchestrator" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+resource "github_repository_ruleset" "RepoOrchestrator_default_ruleset" {
+  name        = "Protect the default branch"
+  repository  = github_repository.RepoOrchestrator.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "pull_request"
+  }
+
+  rules {
+    creation                = false
+    update                  = false
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    pull_request {
+      dismiss_stale_reviews_on_push     = true
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+      required_approving_review_count   = 0
+      required_review_thread_resolution = true
+    }
+
+    required_status_checks {
+      strict_required_status_checks_policy = true
+
+      required_check {
+        context        = "Check Code Quality"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "Check GitHub Actions with zizmor"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "Check Markdown links"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "Label Pull Request"
+        integration_id = 15368
+      }
+    }
+
+    required_code_scanning {
+      required_code_scanning_tool {
+        tool = "zizmor"
+        alerts_threshold = "all"
+        security_alerts_threshold = "critical"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a significant update to the `RepoOrchestrator.tf` file, introducing a new resource to enforce repository rulesets. The most important changes include the addition of a `github_repository_ruleset` resource to protect the default branch and specify various rules and conditions for repository management.

Repository ruleset enforcement:

* [`RepoOrchestrator.tf`](diffhunk://#diff-b9d9313b29a5d0e8d006b846478558435eca3875ea5443b8cc33c1cd9e111b85R21-R85): Added a new `github_repository_ruleset` resource named `RepoOrchestrator_default_ruleset` to protect the default branch with active enforcement. This includes conditions for branch name, bypass actors, and various rules such as creation, update, and deletion restrictions, required linear history, required signatures, and pull request requirements.