### PR TITLE
Add github-stats Repository

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## Add Repositories
 
 - test-project-status-checker
-- github-stats
 - pr-proofreader
 - github-stats-analyser
 - create-repository-tasks

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## Add Repositories
 
 - test-project-status-checker
-- github-pr-analyser
 - github-stats
 - pr-proofreader
 - github-stats-analyser

--- a/github-stats.tf
+++ b/github-stats.tf
@@ -1,10 +1,14 @@
-resource "github_repository" "development-ideas" {
+resource "github_repository" "github-stats" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
-  name         = "development-ideas"
-  description  = "A place to list my project ideas"
-  visibility   = "public"
-  homepage_url = "https://jackplowman.github.io/development-ideas/"
+  name        = "github-stats"
+  description = ""
+  visibility  = "public"
+  homepage_url                = "https://jackplowman.github.io/github-stats/"
+
+  # Repository Features
+  has_issues   = true
+  has_projects = true
 
   # Pull Request settings
   allow_auto_merge            = true

--- a/github-stats.tf
+++ b/github-stats.tf
@@ -1,10 +1,10 @@
 resource "github_repository" "github-stats" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
-  name        = "github-stats"
-  description = ""
-  visibility  = "public"
-  homepage_url                = "https://jackplowman.github.io/github-stats/"
+  name         = "github-stats"
+  description  = ""
+  visibility   = "public"
+  homepage_url = "https://jackplowman.github.io/github-stats/"
 
   # Repository Features
   has_issues   = true

--- a/source_scan.tf
+++ b/source_scan.tf
@@ -26,7 +26,6 @@ resource "github_repository" "source_scan" {
   # GitHub Pages settings
   pages {
     build_type = "workflow"
-
     source {
       branch = "main"
       path   = "/"

--- a/tech-radar.tf
+++ b/tech-radar.tf
@@ -26,7 +26,6 @@ resource "github_repository" "tech-radar" {
   # GitHub Pages settings
   pages {
     build_type = "workflow"
-
     source {
       branch = "main"
       path   = "/"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes across multiple files to update repository configurations and clean up the TODO list. The most important changes include adding a new GitHub repository configuration, removing an entry from the TODO list, and ensuring consistent formatting in GitHub Pages settings.

Repository configuration updates:

* [`github-stats.tf`](diffhunk://#diff-3f069670735ed00ff2eaaeac67ef89f01ccd6fef15012e8ac2b4ddde142dddacR1-R34): Added a new GitHub repository configuration for `github-stats` with various settings including visibility, repository features, pull request settings, and GitHub Pages settings.

Cleanup and formatting:

* [`TODO.md`](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L6): Removed the `github-pr-analyser` entry from the TODO list.
* `development-ideas.tf`, `source_scan.tf`, `tech-radar.tf`: Ensured consistent formatting in the GitHub Pages settings by removing unnecessary blank lines. [[1]](diffhunk://#diff-2d04ef5de4820d7b9bd2dbc2e2a72fa9150df8ff4830f6bec39fa7b39c00b701L25) [[2]](diffhunk://#diff-3c8abd67aa810943d30b694411a7f492f46479f4bf6c70e2d31a36d4d5e4822bL29) [[3]](diffhunk://#diff-526a89b98c3c3a561938742a9955b448f9eda2305f3e8e78ed31f691aaf1b7caL29)