### PR TITLE
Add python-practice Repository

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 - github-stats-analyser
 - create-repository-tasks
 - RepoSync
-- python-practice
 - project-status-checker
 - status-sentinel
 - aws-timing-scripts

--- a/python-practice.tf
+++ b/python-practice.tf
@@ -1,0 +1,24 @@
+resource "github_repository" "python-practice" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name        = "python-practice"
+  description = "A repository for storing completed coding challenges, organised for easy reference and future practice."
+  visibility  = "public"
+
+  # Repository Features
+  has_issues   = true
+  has_projects = true
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads        = false
+  vulnerability_alerts = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes significant changes to the repository configuration and project documentation. The most important changes include the removal of the `python-practice` project from the `TODO.md` file and the addition of a new Terraform configuration for the `python-practice` GitHub repository.

Changes to project documentation:

* [`TODO.md`](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L10): Removed the `python-practice` project from the list.

Repository configuration updates:

* [`python-practice.tf`](diffhunk://#diff-51b86d1e32e35d1c5637af8d100261389693c2b25b0aba22161f9320dc9c3f5dR1-R24): Added a new Terraform configuration to create and manage the `python-practice` GitHub repository with specific settings such as visibility, repository features, pull request settings, and other configurations.