### PR TITLE
Add create-repository-tasks Repository

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
 - test-project-status-checker
 - pr-proofreader
 - github-stats-analyser
-- create-repository-tasks
 - aws-timing-scripts
 
 ## Set attributes

--- a/create-repository-tasks.tf
+++ b/create-repository-tasks.tf
@@ -1,9 +1,9 @@
 resource "github_repository" "create-repository-tasks" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
-  name         = "create-repository-tasks"
-  description  = "A list of tasks to complete when setting up a new repository"
-  visibility   = "public"
+  name        = "create-repository-tasks"
+  description = "A list of tasks to complete when setting up a new repository"
+  visibility  = "public"
 
   # Pull Request settings
   allow_auto_merge            = true

--- a/create-repository-tasks.tf
+++ b/create-repository-tasks.tf
@@ -1,0 +1,34 @@
+resource "github_repository" "create-repository-tasks" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name         = "create-repository-tasks"
+  description  = ""
+  visibility   = "public"
+  homepage_url = "https://jackplowman.github.io/create-repository-tasks/"
+
+  # Repository Features
+  has_issues   = true
+  has_projects = true
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads        = false
+  vulnerability_alerts = true
+
+  # GitHub Pages settings
+  pages {
+    build_type = "workflow"
+    source {
+      branch = "main"
+      path   = "/"
+    }
+  }
+}

--- a/create-repository-tasks.tf
+++ b/create-repository-tasks.tf
@@ -2,13 +2,8 @@ resource "github_repository" "create-repository-tasks" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name         = "create-repository-tasks"
-  description  = ""
+  description  = "A list of tasks to complete when setting up a new repository"
   visibility   = "public"
-  homepage_url = "https://jackplowman.github.io/create-repository-tasks/"
-
-  # Repository Features
-  has_issues   = true
-  has_projects = true
 
   # Pull Request settings
   allow_auto_merge            = true
@@ -22,13 +17,4 @@ resource "github_repository" "create-repository-tasks" {
   # Other settings
   has_downloads        = false
   vulnerability_alerts = true
-
-  # GitHub Pages settings
-  pages {
-    build_type = "workflow"
-    source {
-      branch = "main"
-      path   = "/"
-    }
-  }
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `TODO.md` file and the addition of a new Terraform configuration file to create a GitHub repository with specific settings. The most important changes are summarized below:

### Updates to `TODO.md`:

* Removed the `create-repository-tasks` item from the list.

### Addition of `create-repository-tasks.tf`:

* Added a new Terraform configuration file to create a GitHub repository named `create-repository-tasks` with specific settings, including enabling auto-merge, disabling merge and rebase commits, and setting the repository visibility to public.