### PR TITLE
Add aws-timing-scripts Repository

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,5 @@
 # TODO
 
-## Add Repositories
-
-- test-project-status-checker
-- aws-timing-scripts
-
 ## Set attributes
 
 - Turn on vulnerability alerts

--- a/aws-timing-scripts.tf
+++ b/aws-timing-scripts.tf
@@ -1,0 +1,19 @@
+resource "github_repository" "aws-timing-scripts" {
+  #checkov:skip=CKV2_GIT_1
+  name        = "aws-timing-scripts"
+  description = ""
+  visibility  = "private"
+
+  # Pull Request settings
+  # allow_auto_merge            = true # Disabled for now as repository is private
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads        = false
+  vulnerability_alerts = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `TODO.md` file and the addition of a new GitHub repository resource in the `aws-timing-scripts.tf` file. The most important changes are as follows:

Updates to documentation:

* [`TODO.md`](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L3-L7): Removed the section for adding repositories, specifically the entries for `test-project-status-checker` and `aws-timing-scripts`.

Infrastructure as Code changes:

* [`aws-timing-scripts.tf`](diffhunk://#diff-5df2671438b732b17488a7071a6a4deb349e89d4e86b821cb6c211019bba5289R1-R19): Added a new GitHub repository resource for `aws-timing-scripts` with specific settings for pull requests and other repository configurations.