### PR TITLE
Add RepoOrchestratorState Repository

### DIFF
--- a/RepoOrchestratorState.tf
+++ b/RepoOrchestratorState.tf
@@ -1,0 +1,18 @@
+resource "github_repository" "RepoOrchestratorState" {
+  #checkov:skip=CKV2_GIT_1
+  name        = "RepoOrchestratorState"
+  description = ""
+  visibility  = "private"
+
+  # Pull Request settings
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads        = false
+  vulnerability_alerts = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub repository resource named `RepoOrchestratorState` with specific configuration settings in the `RepoOrchestratorState.tf` file.

Key changes include:

* Added a new GitHub repository resource `RepoOrchestratorState` with the following settings:
  * Disabled merge commits and rebase merges, enabled branch updates, and set to delete branches on merge.
  * Configured squash merge commit message and title to use the PR body and title respectively.
  * Disabled downloads and enabled vulnerability alerts.