### PR TITLE
Refactor Branch Protection Rules into Module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,8 @@ updates:
 
   - package-ecosystem: "terraform"
     directories:
-      - "/"
+      - "/stack"
+      - "/modules/default-branch-protection"
     schedule:
       interval: "weekly"
       day: "saturday"

--- a/modules/default-branch-protection/rules.tf
+++ b/modules/default-branch-protection/rules.tf
@@ -1,0 +1,53 @@
+resource "github_repository_ruleset" "default_ruleset" {
+  name       = "Protect default branch"
+  repository = var.repository_name
+  target     = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = false
+    update                  = false
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+
+    pull_request {
+      dismiss_stale_reviews_on_push     = true
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+      required_approving_review_count   = 0
+      required_review_thread_resolution = true
+    }
+
+    required_status_checks {
+      strict_required_status_checks_policy = true
+
+      dynamic required_check {
+        for_each = var.required_status_checks
+        content {
+          context        = required_check.value
+          integration_id = 15368
+        }
+      }
+    }
+
+    required_code_scanning {
+      dynamic required_code_scanning_tool {
+        for_each = var.required_code_scanning_tools
+        content {
+          tool                      = required_code_scanning_tool.value
+          alerts_threshold          = "all"
+          security_alerts_threshold = "critical"
+        }
+      }
+    }
+  }
+}

--- a/modules/default-branch-protection/rules.tf
+++ b/modules/default-branch-protection/rules.tf
@@ -30,7 +30,7 @@ resource "github_repository_ruleset" "default_ruleset" {
     required_status_checks {
       strict_required_status_checks_policy = true
 
-      dynamic required_check {
+      dynamic "required_check" {
         for_each = var.required_status_checks
         content {
           context        = required_check.value
@@ -40,7 +40,7 @@ resource "github_repository_ruleset" "default_ruleset" {
     }
 
     required_code_scanning {
-      dynamic required_code_scanning_tool {
+      dynamic "required_code_scanning_tool" {
         for_each = var.required_code_scanning_tools
         content {
           tool                      = required_code_scanning_tool.value

--- a/modules/default-branch-protection/rules.tf
+++ b/modules/default-branch-protection/rules.tf
@@ -1,7 +1,7 @@
 resource "github_repository_ruleset" "default_ruleset" {
-  name       = "Protect default branch"
-  repository = var.repository_name
-  target     = "branch"
+  name        = "Protect default branch"
+  repository  = var.repository_name
+  target      = "branch"
   enforcement = "active"
 
   conditions {

--- a/modules/default-branch-protection/variables.tf
+++ b/modules/default-branch-protection/variables.tf
@@ -1,0 +1,14 @@
+variable "repository_name" {
+  description = "The name of the GitHub repository."
+  type        = string
+}
+
+variable "required_status_checks" {
+  description = "A list of required status checks."
+  type        = list(string)
+}
+
+variable "required_code_scanning_tools" {
+  description = "A list of required code scanning tools."
+  type        = list(string)
+}

--- a/modules/default-branch-protection/version.tf
+++ b/modules/default-branch-protection/version.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.8.7"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.4.0"
+    }
+  }
+}

--- a/stack/.terraform.lock.hcl
+++ b/stack/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/github" {
+  version = "6.4.0"
+  hashes = [
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
+    "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
+    "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
+    "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
+    "zh:402ecaa5add568a52ee01d816810f3b90f693be35c680fcdc9b6284bf55326f1",
+    "zh:60e3bdd9fbefb3c1d790bc08889c1dc0e83636b82284faaa709411aa4f96bb9f",
+    "zh:625099eeff2f8aaecd22a24a451b326828435c8f9de86f2e5e99872e7b467fa7",
+    "zh:79e8b665421009df2260f50e10da1f7a7863b557ece96e2b07dfd2fad1e86fcd",
+    "zh:98e471fefc93dcfedeec750c694110db7d3331dc3a256191d30b9d2f70d12157",
+    "zh:a17702765e1fa92d1c288ddfd97075819ad61b344b341be7e09c554c841a6d9e",
+    "zh:ca72ccf40624ae26bf4660d8dd84a51638f0a1e78d5f19fdfaafaef97f838af6",
+    "zh:d009ab5527d45c44c424d26cd2eb51a5a6a6448f3fb1023b675789588cc08d64",
+    "zh:e5811be1e942a75b14dfcd3e03523d8df60cfbde0d7e24d75e78480a02a58949",
+    "zh:e6008ad28225ad6996b06bcd7f3070863329df406a56754e7fb9c31d6301ace4",
+    "zh:f1d93f56ea4f87183a5de4780704907605851d95a2d285a9ec755bf784c5569c",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.4.0"
   constraints = "6.4.0"

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -19,68 +19,17 @@ resource "github_repository" "RepoOrchestrator" {
   vulnerability_alerts = true
 }
 
-resource "github_repository_ruleset" "RepoOrchestrator_default_ruleset" {
-  name        = "Protect the default branch"
-  repository  = github_repository.RepoOrchestrator.name
-  target      = "branch"
-  enforcement = "active"
+module "RepoOrchestrator_default_branch_protection" {
+  source = "../modules/default-branch-protection"
 
-  conditions {
-    ref_name {
-      include = ["~DEFAULT_BRANCH"]
-      exclude = []
-    }
-  }
+  repository_name = github_repository.RepoOrchestrator.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Label Pull Request"
+  ]
+  required_code_scanning_tools = ["zizmor"]
 
-  bypass_actors {
-    actor_id    = 5
-    actor_type  = "RepositoryRole"
-    bypass_mode = "pull_request"
-  }
-
-  rules {
-    creation                = false
-    update                  = false
-    deletion                = true
-    non_fast_forward        = true
-    required_linear_history = true
-    required_signatures     = true
-
-    pull_request {
-      dismiss_stale_reviews_on_push     = true
-      require_code_owner_review         = false
-      require_last_push_approval        = false
-      required_approving_review_count   = 0
-      required_review_thread_resolution = true
-    }
-
-    required_status_checks {
-      strict_required_status_checks_policy = true
-
-      required_check {
-        context        = "Check Code Quality"
-        integration_id = 15368
-      }
-      required_check {
-        context        = "Check GitHub Actions with zizmor"
-        integration_id = 15368
-      }
-      required_check {
-        context        = "Check Markdown links"
-        integration_id = 15368
-      }
-      required_check {
-        context        = "Label Pull Request"
-        integration_id = 15368
-      }
-    }
-
-    required_code_scanning {
-      required_code_scanning_tool {
-        tool                      = "zizmor"
-        alerts_threshold          = "all"
-        security_alerts_threshold = "critical"
-      }
-    }
-  }
+  depends_on = [github_repository.RepoOrchestrator]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes significant changes to the Terraform configuration for managing GitHub repository rulesets. The changes involve modularizing the default branch protection rules and updating dependencies.

### Modularization of Default Branch Protection:

* [`modules/default-branch-protection/rules.tf`](diffhunk://#diff-4dedf3b9da1a018aab107c0736c07f13b68ed197d6f7f8d69239b45b92f17448R1-R53): Added a new resource `github_repository_ruleset` to define default branch protection rules, including conditions, rules, and required checks.
* [`modules/default-branch-protection/variables.tf`](diffhunk://#diff-06f8e4184fbe470dee5bcfc192fb7cbacfb8f03b3924bd268befdc71e4e17f8fR1-R14): Introduced new variables `repository_name`, `required_status_checks`, and `required_code_scanning_tools` to parameterize the module.
* [`stack/RepoOrchestrator.tf`](diffhunk://#diff-91f35e38e4fb154b436ffff883598acbcd0280c0516ddbbfa24d768525b9e306L22-R34): Replaced the inline definition of the `github_repository_ruleset` resource with a reference to the new `default-branch-protection` module.

### Dependency Updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L23-R24): Updated the directories for Terraform package-ecosystem to include `/stack` and `/modules/default-branch-protection`.
* [`modules/default-branch-protection/version.tf`](diffhunk://#diff-083dcdd2848fb453f0966cc360d8160b73b9759560863e07dc0e7ae21f851b8aR1-R9): Specified required Terraform and provider versions for the new module.
* [`stack/.terraform.lock.hcl`](diffhunk://#diff-a977c47fa87684d79003fe5b838ec4f35f5d4437ef888396ae59474faa56cfc0R4-R25): Added hashes for the `github` provider to ensure consistent provider versions across environments.
