### PR TITLE
Add OpenTofu Just Commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------------------
+# Tofu
+# ------------------------------------------------------------------------------
+
+# Initialize the tofu stack
+tofu-init:
+    cd stack && tofu init
+
+# Apply the tofu stack
+tofu-apply:
+    cd stack && tofu apply
+
+tofu-fmt:
+    cd stack && tofu fmt
+    cd modules/default-branch-protection && tofu fmt
+
+
+# ------------------------------------------------------------------------------
+# Prettier - File Formatting
+# ------------------------------------------------------------------------------
+
+# Check for prettier issues
+prettier-check:
+    prettier . --check
+
+# Fix prettier issues
+prettier-format:
+    prettier . --check --write
+
+# ------------------------------------------------------------------------------
+# Justfile
+# ------------------------------------------------------------------------------
+
+# Format the Just code
+format:
+    just --fmt --unstable
+
+# Check for Just format issues
+format-check:
+    just --fmt --check --unstable
+


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several new commands to the `Justfile` to manage the tofu stack and handle file formatting with Prettier. The most important changes include initializing and applying the tofu stack, formatting and checking the tofu stack, and adding Prettier commands for code formatting.

### Tofu stack management:

* Added `tofu-init` command to initialize the tofu stack.
* Added `tofu-apply` command to apply the tofu stack.
* Added `tofu-fmt` command to format the tofu stack and its modules.

### Prettier file formatting:

* Added `prettier-check` command to check for Prettier issues.
* Added `prettier-format` command to fix Prettier issues.