### PR TITLE
Add Just Formatting Checking

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.0.1
+        uses: astral-sh/setup-uv@v5.1.0
         with:
           version: "latest"
       - name: Run zizmor 🌈

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -51,6 +51,20 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -14,7 +14,6 @@ tofu-fmt:
     cd stack && tofu fmt
     cd modules/default-branch-protection && tofu fmt
 
-
 # ------------------------------------------------------------------------------
 # Prettier - File Formatting
 # ------------------------------------------------------------------------------
@@ -38,4 +37,3 @@ format:
 # Check for Just format issues
 format-check:
     just --fmt --check --unstable
-

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -26,8 +26,10 @@ module "RepoOrchestrator_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
     "Check Markdown links",
-    "Label Pull Request"
+    "Dependency Review",
+    "Label Pull Request",
   ]
   required_code_scanning_tools = ["zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the workflow configuration and formatting checks. The most important changes involve adding a new job to check the Justfile format, updating dependencies, and ensuring consistent formatting across files.

### Workflow Configuration Updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R54-R67): Added a new job named `check-justfile-format` to check the Justfile format using the `just format-check` command.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L66-R80): Updated the `setup-uv` action to version `v5.1.0` from `v5.0.1`.

### Formatting and Configuration:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL17): Removed unnecessary blank lines in the `tofu-fmt` and `format-check` sections to ensure consistent formatting. [[1]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL17) [[2]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL41)

### Code Quality Checks:

* [`stack/RepoOrchestrator.tf`](diffhunk://#diff-91f35e38e4fb154b436ffff883598acbcd0280c0516ddbbfa24d768525b9e306R29-R32): Added `Check Justfile Format` and `Dependency Review` to the list of required status checks for the `RepoOrchestrator_default_branch_protection` module.
