### PR TITLE
Add Default Branch Protection Rules (1)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,10 @@
 tofu-init:
     cd stack && tofu init
 
+# Plan the tofu stack
+tofu-plan:
+    cd stack && tofu plan
+
 # Apply the tofu stack
 tofu-apply:
     cd stack && tofu apply

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This repository is used to manage my (JackPlowman) repositories. It is used to k
 ### Tofu
 
 - `just tofu-init`: Initialize the tofu stack.
+- `just tofu-plan`: Plan the tofu stack.
 - `just tofu-apply`: Apply the tofu stack.
 - `just tofu-fmt`: Format the tofu stack and modules.

--- a/stack/.terraform.lock.hcl
+++ b/stack/.terraform.lock.hcl
@@ -1,28 +1,6 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/hashicorp/github" {
-  version = "6.4.0"
-  hashes = [
-    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
-    "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
-    "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
-    "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
-    "zh:402ecaa5add568a52ee01d816810f3b90f693be35c680fcdc9b6284bf55326f1",
-    "zh:60e3bdd9fbefb3c1d790bc08889c1dc0e83636b82284faaa709411aa4f96bb9f",
-    "zh:625099eeff2f8aaecd22a24a451b326828435c8f9de86f2e5e99872e7b467fa7",
-    "zh:79e8b665421009df2260f50e10da1f7a7863b557ece96e2b07dfd2fad1e86fcd",
-    "zh:98e471fefc93dcfedeec750c694110db7d3331dc3a256191d30b9d2f70d12157",
-    "zh:a17702765e1fa92d1c288ddfd97075819ad61b344b341be7e09c554c841a6d9e",
-    "zh:ca72ccf40624ae26bf4660d8dd84a51638f0a1e78d5f19fdfaafaef97f838af6",
-    "zh:d009ab5527d45c44c424d26cd2eb51a5a6a6448f3fb1023b675789588cc08d64",
-    "zh:e5811be1e942a75b14dfcd3e03523d8df60cfbde0d7e24d75e78480a02a58949",
-    "zh:e6008ad28225ad6996b06bcd7f3070863329df406a56754e7fb9c31d6301ace4",
-    "zh:f1d93f56ea4f87183a5de4780704907605851d95a2d285a9ec755bf784c5569c",
-    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
-  ]
-}
-
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.4.0"
   constraints = "6.4.0"

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -18,3 +18,19 @@ resource "github_repository" "create-repository-tasks" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "create-repository-tasks_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.create-repository-tasks.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Dependency Review",
+    "Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor"]
+
+  depends_on = [github_repository.create-repository-tasks]
+}

--- a/stack/depup.tf
+++ b/stack/depup.tf
@@ -22,3 +22,19 @@ resource "github_repository" "depup" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "depup_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.depup.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Dependency Review",
+    "Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor"]
+
+  depends_on = [github_repository.depup]
+}

--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -18,3 +18,20 @@ resource "github_repository" "development-environment" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "development-environment_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.development-environment.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Dependency Review",
+    "Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor"]
+
+  depends_on = [github_repository.development-environment]
+}

--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -28,3 +28,19 @@ resource "github_repository" "development-ideas" {
     }
   }
 }
+
+module "development-ideas_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.development-ideas.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Dependency Review",
+    "Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor"]
+
+  depends_on = [github_repository.development-ideas]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to enhance the Tofu stack management and improve repository security by adding default branch protection modules. The most important changes are summarized below:

Enhancements to Tofu stack management:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR9-R12): Added a new `tofu-plan` command to plan the Tofu stack.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10): Updated the documentation to include the new `tofu-plan` command.

Improvements in repository security:

* [`stack/create-repository-tasks.tf`](diffhunk://#diff-0c65d623333b07f372a64d80bfdae6e2460a61e8634b185074d2800d1d167ceeR21-R36): Added a module for default branch protection to the `create-repository-tasks` resource.
* [`stack/depup.tf`](diffhunk://#diff-3c92e1c0c86a8a62f304958102cc447f8d17732a015d61795417c4f25a91073dR25-R40): Added a module for default branch protection to the `depup` resource.
* [`stack/development-environment.tf`](diffhunk://#diff-00e2788c3b7e75485d7bb7a91b33585cd0412f41347a3c045135761b660ad7a5R21-R37): Added a module for default branch protection to the `development-environment` resource.
* [`stack/development-ideas.tf`](diffhunk://#diff-b235d4ce59faa805849e113c98ed0576b335ba180dbc2db6a06ce02b1beda850R31-R46): Added a module for default branch protection to the `development-ideas` resource.

Additionally, there was a change in the `stack/.terraform.lock.hcl` file to update the provider reference:

* [`stack/.terraform.lock.hcl`](diffhunk://#diff-a977c47fa87684d79003fe5b838ec4f35f5d4437ef888396ae59474faa56cfc0L4-L25): Updated the provider reference from `registry.opentofu.org/hashicorp/github` to `registry.opentofu.org/integrations/github`.