### PR TITLE
Add Default Branch Protection Rules (2)

### DIFF
--- a/stack/GitHubPulse.tf
+++ b/stack/GitHubPulse.tf
@@ -22,3 +22,20 @@ resource "github_repository" "GitHubPulse" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "GitHubPulse_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.GitHubPulse.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Dependency Review",
+    "Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor"]
+
+  depends_on = [github_repository.GitHubPulse]
+}

--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -22,3 +22,23 @@ resource "github_repository" "github-pr-analyser" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "github-pr-analyser_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.github-pr-analyser.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Run Unit Tests",
+    "Dependency Review",
+    "Check Go Format",
+    "CodeQL Analysis",
+    "Run Go Vulnerability Check",
+    "Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.github-pr-analyser]
+}

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -22,3 +22,29 @@ resource "github_repository" "github-stats-analyser" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "github-stats-analyser_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.github-stats-analyser.name
+  required_status_checks = [
+    "Build Docker Image",
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "Check Python Code Format and Quality",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run CodeLimit",
+    "Run Local Action",
+    "Run Unit Tests",
+    "Test GitHub Summary",
+    "Upload Ruff Analysis Results",
+    "Validate Schema",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff"]
+
+  depends_on = [github_repository.github-stats-analyser]
+}

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -32,3 +32,31 @@ resource "github_repository" "github-stats" {
     }
   }
 }
+
+module "github-stats_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.github-stats.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "Check Tests Code Format and Quality",
+    "Check TypeScript Code Format and Quality",
+    "CodeQL Analysis (javascript)",
+    "CodeQL Analysis (python)",
+    "Dependency Review",
+    "Docker Build Test",
+    "Label Pull Request",
+    "Run CodeLimit",
+    "Test GitHub Summary",
+    "Test TypeScript Code",
+    "Upload ESLint Analysis Results",
+    "Upload Ruff Analysis Results",
+    "Validate Schema",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint"]
+
+  depends_on = [github_repository.github-stats]
+}

--- a/stack/pr-proofreader.tf
+++ b/stack/pr-proofreader.tf
@@ -22,3 +22,24 @@ resource "github_repository" "pr-proofreader" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "pr-proofreader_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.pr-proofreader.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check JavaScript Code",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run CodeLimit",
+  ]
+  required_code_scanning_tools = ["CodeQL", "ESLint", "zizmor"]
+
+  depends_on = [github_repository.pr-proofreader]
+}

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -22,3 +22,30 @@ resource "github_repository" "project-status-checker" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "project-status-checker_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.project-status-checker.name
+  required_status_checks = [
+    "Build Docker Image and Run",
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "Check Pull Request Title",
+    "Check Python Code Format and Quality",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run CodeLimit",
+    "Run Local Project Status Checker Action",
+    "Run Unit Tests",
+    "Test GitHub Summary",
+    "Upload Python Ruff Scanner Results",
+  ]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor"]
+
+  depends_on = [github_repository.project-status-checker]
+}

--- a/stack/python-practice.tf
+++ b/stack/python-practice.tf
@@ -22,3 +22,23 @@ resource "github_repository" "python-practice" {
   has_downloads        = false
   vulnerability_alerts = true
 }
+
+module "python-practice_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.python-practice.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Check Python Code Format and Quality",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run Unit Tests",
+  ]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor"]
+
+  depends_on = [github_repository.python-practice]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the addition of default branch protection modules to several GitHub repositories. These changes ensure that each repository has specific status checks and code scanning tools configured for branch protection.

Branch protection modules added:

* [`stack/GitHubPulse.tf`](diffhunk://#diff-f5705c387892a1d3f3fb63d26c09f12b915bb70f1a541cd9a42b82e404533371R25-R41): Added branch protection with required status checks and code scanning tools for the `GitHubPulse` repository.
* [`stack/github-pr-analyser.tf`](diffhunk://#diff-432bae1b13646e0510fa8807f1fcf29e9bb903141c00a6f1958c3ae7df2c16f7R25-R44): Added branch protection with required status checks and code scanning tools for the `github-pr-analyser` repository.
* [`stack/github-stats-analyser.tf`](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bR25-R50): Added branch protection with required status checks and code scanning tools for the `github-stats-analyser` repository.
* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1R35-R62): Added branch protection with required status checks and code scanning tools for the `github-stats` repository.
* [`stack/pr-proofreader.tf`](diffhunk://#diff-8c4a5099a96de6f7b5b99ee5b58085159fd83619f4e6034f7e6b42323c07ea05R25-R45): Added branch protection with required status checks and code scanning tools for the `pr-proofreader` repository.
* [`stack/project-status-checker.tf`](diffhunk://#diff-2a4b5a746b5b79e9a3d33092afd952c2b24b3362b4204558c86fd6b917efe8dfR25-R51): Added branch protection with required status checks and code scanning tools for the `project-status-checker` repository.
* [`stack/python-practice.tf`](diffhunk://#diff-1a54e41d03518683485b02101e0364624e00cd74300a32a95093acc7f483306dR25-R44): Added branch protection with required status checks and code scanning tools for the `python-practice` repository.