### PR TITLE
Fix Source Scan Rules

### DIFF
--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -50,7 +50,7 @@ module "source_scan_default_branch_protection" {
     "Label Pull Request",
     "Run CodeLimit",
     "Run Unit Tests",
-    "Upload Python Ruff Scanner Results",
+    "Upload Ruff Analysis Results",
   ]
   required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `stack/source_scan.tf` file. The change involves renaming a step in the list of actions for the default branch protection module.

* [`stack/source_scan.tf`](diffhunk://#diff-4b3bf164059b483435d7002f084e05adc33a2a964754f30a5ebc79fa8489ee26L53-R53): Updated the action name from "Upload Python Ruff Scanner Results" to "Upload Ruff Analysis Results".