### PR TITLE
Fix and Improve GitHub Stats Checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -51,13 +51,11 @@ module "github-stats_default_branch_protection" {
     "Docker Build Test",
     "Label Pull Request",
     "Run CodeLimit",
-    "Test GitHub Summary",
     "Test TypeScript Code",
     "Upload ESLint Analysis Results",
     "Upload Ruff Analysis Results",
-    "Validate Schema",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "SonarCloud"]
 
   depends_on = [github_repository.github-stats]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `stack/github-stats.tf` file to update the default branch protection settings for the GitHub repository. The most important changes include the removal of certain required status checks and the addition of a new code scanning tool.

Updates to default branch protection settings:

* Removed the "Test GitHub Summary" and "Validate Schema" status checks from the list of required status checks.
* Added "SonarCloud" to the list of required code scanning tools.