### PR TITLE
Fix Python Practice Scanning

### DIFF
--- a/stack/python-practice.tf
+++ b/stack/python-practice.tf
@@ -30,7 +30,6 @@ module "python-practice_default_branch_protection" {
   repository_name = github_repository.python-practice.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
     "Check Justfile Format",
     "Check Markdown links",
     "Check Python Code Format and Quality",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `stack/python-practice.tf` file to update the required status checks for the `python-practice` repository. The change involves removing an outdated status check.

Changes to required status checks:

* [`stack/python-practice.tf`](diffhunk://#diff-1a54e41d03518683485b02101e0364624e00cd74300a32a95093acc7f483306dL33): Removed the "Check GitHub Actions with zizmor" status check from the `required_status_checks` list.