### PR TITLE
Fix Python Practice Scanning 2

### DIFF
--- a/stack/python-practice.tf
+++ b/stack/python-practice.tf
@@ -38,7 +38,7 @@ module "python-practice_default_branch_protection" {
     "Label Pull Request",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "Ruff"]
 
   depends_on = [github_repository.python-practice]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/python-practice.tf` file. The change removes the `zizmor` tool from the list of `required_code_scanning_tools`.

* [`stack/python-practice.tf`](diffhunk://#diff-1a54e41d03518683485b02101e0364624e00cd74300a32a95093acc7f483306dL41-R41): Removed `zizmor` from the `required_code_scanning_tools` list.