### PR TITLE
Add Public Repository Security Settings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,6 @@
 
 ## Set attributes
 
-- Turn on vulnerability alerts
-- Turn on GitHub Pages (if applicable)
-- Turn on secret scanning
-- Turn off discussions
 - Turn on dependabot security updates
 
 ## Other

--- a/stack/GitHubPulse.tf
+++ b/stack/GitHubPulse.tf
@@ -22,6 +22,16 @@ resource "github_repository" "GitHubPulse" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "GitHubPulse_default_branch_protection" {

--- a/stack/JackPlowman.tf
+++ b/stack/JackPlowman.tf
@@ -18,4 +18,14 @@ resource "github_repository" "JackPlowman" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -18,6 +18,16 @@ resource "github_repository" "RepoOrchestrator" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "RepoOrchestrator_default_branch_protection" {

--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -18,6 +18,16 @@ resource "github_repository" "RepoSync" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "RepoSync_default_branch_protection" {

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -18,6 +18,16 @@ resource "github_repository" "create-repository-tasks" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "create-repository-tasks_default_branch_protection" {

--- a/stack/depup.tf
+++ b/stack/depup.tf
@@ -22,6 +22,16 @@ resource "github_repository" "depup" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "depup_default_branch_protection" {

--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -18,6 +18,16 @@ resource "github_repository" "development-environment" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "development-environment_default_branch_protection" {

--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -20,6 +20,16 @@ resource "github_repository" "development-ideas" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
   # GitHub Pages settings
   pages {
     build_type = "workflow"

--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -22,6 +22,16 @@ resource "github_repository" "github-pr-analyser" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "github-pr-analyser_default_branch_protection" {

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -22,6 +22,16 @@ resource "github_repository" "github-stats-analyser" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "github-stats-analyser_default_branch_protection" {

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -24,6 +24,16 @@ resource "github_repository" "github-stats" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
   # GitHub Pages settings
   pages {
     build_type = "workflow"

--- a/stack/pls.tf
+++ b/stack/pls.tf
@@ -23,6 +23,15 @@ resource "github_repository" "pls" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "pls_default_branch_protection" {

--- a/stack/pr-proofreader.tf
+++ b/stack/pr-proofreader.tf
@@ -22,6 +22,16 @@ resource "github_repository" "pr-proofreader" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "pr-proofreader_default_branch_protection" {

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -22,6 +22,16 @@ resource "github_repository" "project-status-checker" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "project-status-checker_default_branch_protection" {

--- a/stack/python-practice.tf
+++ b/stack/python-practice.tf
@@ -22,6 +22,16 @@ resource "github_repository" "python-practice" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "python-practice_default_branch_protection" {

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -21,6 +21,16 @@ resource "github_repository" "screenshot_mailinator_email" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }
 
 module "screenshot_mailinator_email_default_branch_protection" {

--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -24,6 +24,16 @@ resource "github_repository" "source_scan" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
   # GitHub Pages settings
   pages {
     build_type = "workflow"

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -24,6 +24,16 @@ resource "github_repository" "status-sentinel" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
   # GitHub Pages settings
   pages {
     build_type = "workflow"

--- a/stack/tech-radar.tf
+++ b/stack/tech-radar.tf
@@ -24,6 +24,16 @@ resource "github_repository" "tech-radar" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
   # GitHub Pages settings
   pages {
     build_type = "workflow"

--- a/stack/test-project-status-checker.tf
+++ b/stack/test-project-status-checker.tf
@@ -18,4 +18,14 @@ resource "github_repository" "test-project-status-checker" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to enhance the security settings of multiple GitHub repositories by enabling secret scanning and push protection. Additionally, some minor updates were made to the `TODO.md` file.

Security enhancements:

* Added `security_and_analysis` block with `secret_scanning` and `secret_scanning_push_protection` enabled for the following repositories:
  * `GitHubPulse` in `stack/GitHubPulse.tf`
  * `JackPlowman` in `stack/JackPlowman.tf`
  * `RepoOrchestrator` in `stack/RepoOrchestrator.tf`
  * `RepoSync` in `stack/RepoSync.tf`
  * `create-repository-tasks` in `stack/create-repository-tasks.tf`
  * `depup` in `stack/depup.tf`
  * `development-environment` in `stack/development-environment.tf`
  * `development-ideas` in `stack/development-ideas.tf`
  * `github-pr-analyser` in `stack/github-pr-analyser.tf`
  * `github-stats-analyser` in `stack/github-stats-analyser.tf`
  * `github-stats` in `stack/github-stats.tf`
  * `pls` in `stack/pls.tf`
  * `pr-proofreader` in `stack/pr-proofreader.tf`
  * `project-status-checker` in `stack/project-status-checker.tf`
  * `python-practice` in `stack/python-practice.tf`
  * `screenshot_mailinator_email` in `stack/screenshot_mailinator_email.tf`
  * `source_scan` in `stack/source_scan.tf`
  * `status-sentinel` in `stack/status-sentinel.tf`
  * `tech-radar` in `stack/tech-radar.tf`

Minor updates:

* Removed outdated tasks from `TODO.md`