### PR TITLE
Make aws-timing-scripts public

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -2,7 +2,7 @@ resource "github_repository" "aws-timing-scripts" {
   #checkov:skip=CKV2_GIT_1
   name        = "aws-timing-scripts"
   description = ""
-  visibility  = "private"
+  visibility  = "public"
 
   # Pull Request settings
   # allow_auto_merge            = true # Disabled for now as repository is private
@@ -17,4 +17,14 @@ resource "github_repository" "aws-timing-scripts" {
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
 }

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -1,4 +1,5 @@
 resource "github_repository" "aws-timing-scripts" {
+  #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name        = "aws-timing-scripts"
   description = ""


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `stack/aws-timing-scripts.tf` file to update repository settings and enhance security measures.

Repository settings updates:
* Changed the repository visibility from `private` to `public`.

Security enhancements:
* Added a `security_and_analysis` block to enable `secret_scanning` and `secret_scanning_push_protection`.