### PR TITLE
Add aws-timing-scripts Status Checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -29,3 +29,22 @@ resource "github_repository" "aws-timing-scripts" {
     }
   }
 }
+
+module "aws-timing-scripts_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.aws-timing-scripts.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run CodeLimit",
+    "Upload Ruff Analysis Results",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff"]
+
+  depends_on = [github_repository.aws-timing-scripts]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module for default branch protection to the `aws-timing-scripts` repository. The key change involves adding a module that enforces branch protection rules and required status checks.

Branch protection enhancements:

* [`stack/aws-timing-scripts.tf`](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceR32-R50): Added a new module `aws-timing-scripts_default_branch_protection` to enforce default branch protection. This includes specifying required status checks and code scanning tools, and setting a dependency on the `aws-timing-scripts` repository.