### PR TITLE
Update aws-timing-scripts repository rules and status checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -6,7 +6,7 @@ resource "github_repository" "aws-timing-scripts" {
   visibility  = "public"
 
   # Pull Request settings
-  # allow_auto_merge            = true # Disabled for now as repository is private
+  allow_auto_merge            = true
   allow_merge_commit          = false
   allow_rebase_merge          = false
   allow_update_branch         = true
@@ -42,7 +42,7 @@ module "aws-timing-scripts_default_branch_protection" {
     "Dependency Review",
     "Label Pull Request",
     "Run CodeLimit",
-    "Upload Ruff Analysis Results",
+    "Run Python Code Checks",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `stack/aws-timing-scripts.tf` file to update the repository settings and modify the branch protection rules.

Repository settings update:

* Enabled the `allow_auto_merge` setting for the `github_repository` resource.

Branch protection rules modification:

* Replaced "Upload Ruff Analysis Results" with "Run Python Code Checks" in the list of required status checks for the `aws-timing-scripts_default_branch_protection` module.
