### PR TITLE
Mark Repository Template as Template

### DIFF
--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -15,7 +15,7 @@ resource "github_repository" "repository-template" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  is_template = true
+  is_template                 = true
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -15,6 +15,7 @@ resource "github_repository" "repository-template" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
+  is_template = true
   has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/repository-template.tf` file. The change sets the `is_template` attribute to `true` for the `github_repository` resource. 

* [`stack/repository-template.tf`](diffhunk://#diff-e423eafcab1924cdae12635150f2d1fbe733b23ad035d3f61dcf8ea5a1d4f4fbR18): Added `is_template = true` to the `github_repository` resource.
