### PR TITLE
Add Repo Standards Validator Default Branch Protection

### DIFF
--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -34,3 +34,26 @@ resource "github_repository" "repo_standards_validator" {
   }
 }
 
+module "repo_standards_validator_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.repo_standards_validator.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run CodeLimit",
+    "Run Local Action",
+    "Run Python Code Checks",
+    "Run Unit Tests",
+    "Validate Schema",
+  ]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud"]
+
+  depends_on = [github_repository.repo_standards_validator]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module for default branch protection in the `repo_standards_validator` repository. The most important change is the addition of a module that enforces various required status checks and code scanning tools for the repository.

Branch protection module:

* [`stack/repo_standards_validator.tf`](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cR37-R59): Added a new module `repo_standards_validator_default_branch_protection` to enforce default branch protection with specified required status checks and code scanning tools.
