### PR TITLE
Add repo-overseer Status Checks

### DIFF
--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -42,3 +42,25 @@ resource "github_repository" "repo-overseer" {
     }
   }
 }
+
+module "repo-overseer_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.repo-overseer.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "Run TypeScript Code Checks",
+    "CodeQL Analysis (python)",
+    "CodeQL Analysis (javascript)",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run Python Code Checks",
+  ]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor"]
+
+  depends_on = [github_repository.repo-overseer]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a significant change to the `stack/repo-overseer.tf` file. The change introduces a new module for default branch protection for the `repo-overseer` repository.

Branch protection module addition:

* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aR45-R66): Added a new module `repo-overseer_default_branch_protection` to enforce branch protection rules on the `repo-overseer` repository. This includes specifying required status checks such as "Check Code Quality", "Run TypeScript Code Checks", and "CodeQL Analysis (python)", among others. It also includes required code scanning tools like "CodeQL", "Ruff", and "zizmor".
