### PR TITLE
Fix Useful Commands Status Checks

### DIFF
--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -32,7 +32,6 @@ module "useful-commands_default_branch_protection" {
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
     "Check Markdown links",
-    "Check Pull Request Title",
     "CodeQL Analysis",
     "Dependency Review",
     "Label Pull Request",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/useful-commands.tf` file. The change removes the "Check Pull Request Title" command from the list of useful commands.
