### PR TITLE
Fix GitHub Pulse Status Checks

### DIFF
--- a/stack/GitHubPulse.tf
+++ b/stack/GitHubPulse.tf
@@ -41,7 +41,6 @@ module "GitHubPulse_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
     "Check Markdown links",
     "Dependency Review",
     "Label Pull Request",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/GitHubPulse.tf` file. The change removes the "Check Justfile Format" status check from the required status checks list.

* [`stack/GitHubPulse.tf`](diffhunk://#diff-f5705c387892a1d3f3fb63d26c09f12b915bb70f1a541cd9a42b82e404533371L44): Removed "Check Justfile Format" from the `required_status_checks` list.