### PR TITLE
Set Precise Tofu Version

### DIFF
--- a/modules/default-branch-protection/version.tf
+++ b/modules/default-branch-protection/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8.7"
+  required_version = "1.9.0"
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `modules/default-branch-protection/version.tf` file. The change updates the required Terraform version to `1.9.0`.

* [`modules/default-branch-protection/version.tf`](diffhunk://#diff-083dcdd2848fb453f0966cc360d8160b73b9759560863e07dc0e7ae21f851b8aL2-R2): Updated the required Terraform version from `>= 1.8.7` to `1.9.0`.
