### PR TITLE
Update RepoSync Status Checks

### DIFF
--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -37,6 +37,7 @@ module "RepoSync_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
+    "Check Markdown links",
     "CodeQL Analysis",
     "Label Pull Request",
   ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/RepoSync.tf` file. The change adds a new required status check for "Check Markdown links" in the `RepoSync_default_branch_protection` module.

* [`stack/RepoSync.tf`](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beR40): Added "Check Markdown links" to the list of required status checks.