### PR TITLE
Add Dependabot Security Updates to All Repositories

### DIFF
--- a/stack/GitHubPulse.tf
+++ b/stack/GitHubPulse.tf
@@ -34,6 +34,11 @@ resource "github_repository" "GitHubPulse" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "GitHubPulse" {
+  repository = github_repository.GitHubPulse.name
+  enabled    = true
+}
+
 module "GitHubPulse_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/JackPlowman.tf
+++ b/stack/JackPlowman.tf
@@ -29,3 +29,8 @@ resource "github_repository" "JackPlowman" {
     }
   }
 }
+
+resource "github_repository_dependabot_security_updates" "JackPlowman" {
+  repository = github_repository.JackPlowman.name
+  enabled    = true
+}

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -30,6 +30,11 @@ resource "github_repository" "RepoOrchestrator" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "RepoOrchestrator" {
+  repository = github_repository.RepoOrchestrator.name
+  enabled    = true
+}
+
 module "RepoOrchestrator_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/RepoOrchestratorState.tf
+++ b/stack/RepoOrchestratorState.tf
@@ -17,3 +17,8 @@ resource "github_repository" "RepoOrchestratorState" {
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 }
+
+resource "github_repository_dependabot_security_updates" "RepoOrchestratorState" {
+  repository = github_repository.RepoOrchestratorState.name
+  enabled    = true
+}

--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -30,6 +30,11 @@ resource "github_repository" "RepoSync" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "RepoSync" {
+  repository = github_repository.RepoSync.name
+  enabled    = true
+}
+
 module "RepoSync_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -30,6 +30,11 @@ resource "github_repository" "aws-timing-scripts" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "aws-timing-scripts" {
+  repository = github_repository.aws-timing-scripts.name
+  enabled    = true
+}
+
 module "aws-timing-scripts_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -30,6 +30,11 @@ resource "github_repository" "create-repository-tasks" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "create-repository-tasks" {
+  repository = github_repository.create-repository-tasks.name
+  enabled    = true
+}
+
 module "create-repository-tasks_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/depup.tf
+++ b/stack/depup.tf
@@ -34,6 +34,11 @@ resource "github_repository" "depup" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "depup" {
+  repository = github_repository.depup.name
+  enabled    = true
+}
+
 module "depup_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -30,6 +30,11 @@ resource "github_repository" "development-environment" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "development-environment" {
+  repository = github_repository.development-environment.name
+  enabled    = true
+}
+
 module "development-environment_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -40,6 +40,11 @@ resource "github_repository" "development-ideas" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "development-ideas" {
+  repository = github_repository.development-ideas.name
+  enabled    = true
+}
+
 module "development-ideas_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -34,6 +34,11 @@ resource "github_repository" "github-pr-analyser" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "github-pr-analyser" {
+  repository = github_repository.github-pr-analyser.name
+  enabled    = true
+}
+
 module "github-pr-analyser_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -34,6 +34,11 @@ resource "github_repository" "github-stats-analyser" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "github-stats-analyser" {
+  repository = github_repository.github-stats-analyser.name
+  enabled    = true
+}
+
 module "github-stats-analyser_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -44,6 +44,11 @@ resource "github_repository" "github-stats" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "github-stats" {
+  repository = github_repository.github-stats.name
+  enabled    = true
+}
+
 module "github-stats_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/pr-proofreader.tf
+++ b/stack/pr-proofreader.tf
@@ -34,6 +34,11 @@ resource "github_repository" "pr-proofreader" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "pr-proofreader" {
+  repository = github_repository.pr-proofreader.name
+  enabled    = true
+}
+
 module "pr-proofreader_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -34,6 +34,11 @@ resource "github_repository" "project-status-checker" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "project-status-checker" {
+  repository = github_repository.project-status-checker.name
+  enabled    = true
+}
+
 module "project-status-checker_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/python-practice.tf
+++ b/stack/python-practice.tf
@@ -34,6 +34,11 @@ resource "github_repository" "python-practice" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "python-practice" {
+  repository = github_repository.python-practice.name
+  enabled    = true
+}
+
 module "python-practice_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -44,6 +44,11 @@ resource "github_repository" "repo-overseer" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "repo-overseer" {
+  repository = github_repository.repo-overseer.name
+  enabled    = true
+}
+
 module "repo-overseer_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -34,6 +34,11 @@ resource "github_repository" "repo_standards_validator" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "repo_standards_validator" {
+  repository = github_repository.repo_standards_validator.name
+  enabled    = true
+}
+
 module "repo_standards_validator_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -31,6 +31,11 @@ resource "github_repository" "repository-template" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "repository-template" {
+  repository = github_repository.repository-template.name
+  enabled    = true
+}
+
 module "repository-template_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -33,6 +33,11 @@ resource "github_repository" "screenshot_mailinator_email" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "screenshot_mailinator_email" {
+  repository = github_repository.screenshot_mailinator_email.name
+  enabled    = true
+}
+
 module "screenshot_mailinator_email_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -44,6 +44,11 @@ resource "github_repository" "source_scan" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "source_scan" {
+  repository = github_repository.source_scan.name
+  enabled    = true
+}
+
 module "source_scan_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -44,6 +44,11 @@ resource "github_repository" "status-sentinel" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "status-sentinel" {
+  repository = github_repository.status-sentinel.name
+  enabled    = true
+}
+
 module "status-sentinel_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/tech-radar.tf
+++ b/stack/tech-radar.tf
@@ -44,6 +44,11 @@ resource "github_repository" "tech-radar" {
   }
 }
 
+resource "github_repository_dependabot_security_updates" "tech-radar" {
+  repository = github_repository.tech-radar.name
+  enabled    = true
+}
+
 module "tech-radar_default_branch_protection" {
   source = "../modules/default-branch-protection"
 

--- a/stack/test-project-status-checker.tf
+++ b/stack/test-project-status-checker.tf
@@ -29,3 +29,8 @@ resource "github_repository" "test-project-status-checker" {
     }
   }
 }
+
+resource "github_repository_dependabot_security_updates" "test-project-status-checker" {
+  repository = github_repository.test-project-status-checker.name
+  enabled    = true
+}

--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -40,3 +40,8 @@ module "useful-commands_default_branch_protection" {
 
   depends_on = [github_repository.useful-commands]
 }
+
+resource "github_repository_dependabot_security_updates" "useful-commands" {
+  repository = github_repository.useful-commands.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the addition of Dependabot security updates to several GitHub repositories. The most important changes are the inclusion of a new Terraform resource, `github_repository_dependabot_security_updates`, for each repository to enable automatic security updates.

### Addition of Dependabot Security Updates:

* [`stack/GitHubPulse.tf`](diffhunk://#diff-f5705c387892a1d3f3fb63d26c09f12b915bb70f1a541cd9a42b82e404533371R37-R41): Added `github_repository_dependabot_security_updates` for the `GitHubPulse` repository.
* [`stack/JackPlowman.tf`](diffhunk://#diff-64f71461b75090c0c57ebef2293d861e4b4e8b71e819bc079265e5525ab45b4cR32-R36): Added `github_repository_dependabot_security_updates` for the `JackPlowman` repository.
* [`stack/RepoOrchestrator.tf`](diffhunk://#diff-91f35e38e4fb154b436ffff883598acbcd0280c0516ddbbfa24d768525b9e306R33-R37): Added `github_repository_dependabot_security_updates` for the `RepoOrchestrator` repository.
* [`stack/RepoOrchestratorState.tf`](diffhunk://#diff-547f611809e14b7aeaba133efa6ac141fae7fa97db4380b01c751272014b992bR20-R24): Added `github_repository_dependabot_security_updates` for the `RepoOrchestratorState` repository.
* [`stack/RepoSync.tf`](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beR33-R37): Added `github_repository_dependabot_security_updates` for the `RepoSync` repository.

These changes ensure that Dependabot security updates are enabled across multiple repositories, enhancing the overall security posture by automating the process of keeping dependencies up to date.