### PR TITLE
Add repository-visualiser Repository

### DIFF
--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -1,0 +1,37 @@
+resource "github_repository" "repository-visualiser" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name        = "repository-visualiser"
+  description = ""
+  visibility  = "public"
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  is_template                 = true
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+}
+
+resource "github_repository_dependabot_security_updates" "repository-visualiser" {
+  repository = github_repository.repository-visualiser.name
+  enabled    = true
+}

--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -29,6 +29,12 @@ resource "github_repository" "repository-visualiser" {
       status = "enabled"
     }
   }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
 }
 
 resource "github_repository_dependabot_security_updates" "repository-visualiser" {


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub repository configuration for the `repository-visualiser` project in the `stack/repository-visualiser.tf` file. The main changes include setting up repository settings, pull request settings, security settings, and enabling Dependabot security updates.

Key changes include:

Repository settings:
* Created a new GitHub repository resource named `repository-visualiser` with public visibility and other settings like template usage and web commit signoff requirement.

Pull request settings:
* Configured pull request settings to allow auto-merge, disallow merge and rebase commits, and enforce branch deletion on merge.

Security settings:
* Enabled secret scanning and secret scanning push protection for the repository.

Dependabot security updates:
* Enabled Dependabot security updates for the `repository-visualiser` repository.
