### PR TITLE
Rename to python-practise

### DIFF
--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -1,8 +1,8 @@
-resource "github_repository" "python-practice" {
+resource "github_repository" "python-practise" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
-  name        = "python-practice"
-  description = "A repository for storing completed coding challenges, organised for easy reference and future practice."
+  name        = "python-practise"
+  description = "A repository for storing completed coding challenges, organised for easy reference and future practise."
   visibility  = "public"
 
   # Repository Features
@@ -34,15 +34,15 @@ resource "github_repository" "python-practice" {
   }
 }
 
-resource "github_repository_dependabot_security_updates" "python-practice" {
-  repository = github_repository.python-practice.name
+resource "github_repository_dependabot_security_updates" "python-practise" {
+  repository = github_repository.python-practise.name
   enabled    = true
 }
 
-module "python-practice_default_branch_protection" {
+module "python-practise_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
-  repository_name = github_repository.python-practice.name
+  repository_name = github_repository.python-practise.name
   required_status_checks = [
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
@@ -57,5 +57,5 @@ module "python-practice_default_branch_protection" {
   ]
   required_code_scanning_tools = ["CodeQL", "Ruff", "SonarCloud", "zizmor"]
 
-  depends_on = [github_repository.python-practice]
+  depends_on = [github_repository.python-practise]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to rename the repository from "python-practice" to "python-practise" and update related configurations in the `stack/python-practise.tf` file. The most important changes include renaming resources and modules to reflect the new repository name.

Repository renaming and configuration updates:

* [`stack/python-practise.tf`](diffhunk://#diff-fc110097cfb0503bf0fed5f3d3998731b426ace7a06d573b182e31126ca3ecebL1-R5): Renamed from `stack/python-practice.tf` and updated the `github_repository` resource name from "python-practice" to "python-practise". Updated the repository description to use "practise" instead of "practice".
* [`stack/python-practise.tf`](diffhunk://#diff-fc110097cfb0503bf0fed5f3d3998731b426ace7a06d573b182e31126ca3ecebL37-R45): Updated `resource "github_repository_dependabot_security_updates"` to use the renamed repository "python-practise".
* [`stack/python-practise.tf`](diffhunk://#diff-fc110097cfb0503bf0fed5f3d3998731b426ace7a06d573b182e31126ca3ecebL60-R60): Updated `module "python-practise_default_branch_protection"` to use the renamed repository "python-practise" and updated the `depends_on` attribute accordingly.
