### PR TITLE
Fix github-stats status checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -56,6 +56,7 @@ module "github-stats_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
     "Check Markdown links",
     "Check Pull Request Title",
     "CodeQL Analysis (actions)",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/github-stats.tf` file. The change adds a new required status check for "Check Justfile Format" to the `github-stats_default_branch_protection` module.