### PR TITLE
Update github-pr-analysis status checks

### DIFF
--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -47,12 +47,15 @@ module "github-pr-analyser_default_branch_protection" {
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
     "Check Go Format",
+    "Check Justfile Format",
     "Check Markdown links",
+    "Check Pull Request Title",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (go)",
     "Dependency Review",
     "Label Pull Request",
     "Run Go Vulnerability Check",
+    "Run Local Action",
     "Run Unit Tests",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the default branch protection rules in the `github-pr-analyser` module. The changes primarily involve adding new checks to the list of required status checks.

Updates to default branch protection rules:

* [`stack/github-pr-analyser.tf`](diffhunk://#diff-432bae1b13646e0510fa8807f1fcf29e9bb903141c00a6f1958c3ae7df2c16f7R50-R58): Added new checks "Check Justfile Format", "Check Pull Request Title", and "Run Local Action" to the list of required status checks.
