### PR TITLE
Add actions-status Dependabot Security Updates

### DIFF
--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -37,3 +37,7 @@ resource "github_repository" "actions-status" {
 }
 
 
+resource "github_repository_dependabot_security_updates" "actions-status" {
+  repository = github_repository.actions-status.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `stack/actions-status.tf` file to enable Dependabot security updates for the `actions-status` repository.

* [`stack/actions-status.tf`](diffhunk://#diff-8bd85a029b91639709afbcaa82f1b76b17e52f673c261899307786a1d68a7ebbR40-R43): Added a new `github_repository_dependabot_security_updates` resource to enable Dependabot security updates for the `actions-status` repository.