### PR TITLE
Update aws-timing-scripts status checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -42,6 +42,7 @@ module "aws-timing-scripts_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
     "Check Markdown links",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/aws-timing-scripts.tf` file. The change adds a new required status check to the branch protection settings.

* [`stack/aws-timing-scripts.tf`](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceR45): Added "Check Justfile Format" to the list of required status checks.