### PR TITLE
Update repository-template status checks

### DIFF
--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -56,8 +56,8 @@ module "development-ideas_default_branch_protection" {
     "Check Markdown links",
     "CodeQL Analysis",
     "Dependency Review",
-    "Lefthook Validate",
     "Label Pull Request",
+    "Lefthook Validate",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -48,6 +48,7 @@ module "repository-template_default_branch_protection" {
     "CodeQL Analysis",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the default branch protection configurations for two modules in the Terraform stack. The changes ensure that the "Lefthook Validate" check is consistently included in the list of required status checks.

Updates to default branch protection configurations:

* [`stack/development-ideas.tf`](diffhunk://#diff-b235d4ce59faa805849e113c98ed0576b335ba180dbc2db6a06ce02b1beda850L59-R60): Reordered the status checks to include "Lefthook Validate" after "Label Pull Request".
* [`stack/repository-template.tf`](diffhunk://#diff-e423eafcab1924cdae12635150f2d1fbe733b23ad035d3f61dcf8ea5a1d4f4fbR51): Added "Lefthook Validate" to the list of required status checks.