### PR TITLE
Add Terraform Format pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Tofu Format Checks:
+      run: just tofu-fmt-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `lefthook.yml` file. The change adds a new pre-commit check for Tofu format validation.

* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dR21-R22): Added a new pre-commit check named "Tofu Format Checks" to run `just tofu-fmt-check`.