### PR TITLE
Update create-repository-tasks status checks

### DIFF
--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -47,6 +47,7 @@ module "create-repository-tasks_default_branch_protection" {
     "CodeQL Analysis",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
   ]
   required_code_scanning_tools = ["zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/create-repository-tasks.tf` file. The change adds a new task to the list of default branch protection tasks for repositories.

* [`stack/create-repository-tasks.tf`](diffhunk://#diff-0c65d623333b07f372a64d80bfdae6e2460a61e8634b185074d2800d1d167ceeR50): Added "Lefthook Validate" to the list of default branch protection tasks.