### PR TITLE
Update github-stats status checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -65,6 +65,7 @@ module "github-stats_default_branch_protection" {
     "Dependency Review",
     "Docker Build Test",
     "Label Pull Request",
+    "Lefthook Validate",
     "Run CodeLimit",
     "Run Python Code Checks",
     "Run TypeScript Code Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/github-stats.tf` file. The change adds "Lefthook Validate" to the list of GitHub Actions workflows for the default branch protection.

* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1R68): Added "Lefthook Validate" to the list of workflows in the default branch protection configuration.