### PR TITLE
Add DependabotTrigger Status Checks

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -45,3 +45,22 @@ resource "github_repository_dependabot_security_updates" "DependabotTrigger" {
   repository = github_repository.DependabotTrigger.name
   enabled    = true
 }
+
+module "DependabotTrigger_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.DependabotTrigger.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Lefthook Validate",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.DependabotTrigger]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a module to enforce branch protection rules for the `DependabotTrigger` repository in the Terraform configuration. The most important change is the addition of a new module that sets up default branch protection with specific required status checks and code scanning tools.

Branch protection enforcement:

* [`stack/DependabotTrigger.tf`](diffhunk://#diff-b8a57b2da236fd1ca2ca395e71438ecc3f420e5f8f55317e5ae636a4091f30a2R48-R66): Added a module named `DependabotTrigger_default_branch_protection` to enforce branch protection rules, including required status checks and code scanning tools for the `DependabotTrigger` repository.