### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -90,7 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.11
+        uses: github/codeql-action/upload-sarif@v3.28.12
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -123,10 +123,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.11
+        uses: github/codeql-action/init@v3.28.12
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.11
+        uses: github/codeql-action/analyze@v3.28.12

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.12
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -123,10 +123,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.12
+        uses: github/codeql-action/init@v3.28.13
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.12
+        uses: github/codeql-action/analyze@v3.28.13

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Check Justfile Format
         run: just format-check
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to several dependencies in the `.github/workflows/code-checks.yml` file to ensure the latest versions are being used for various actions.

Dependency updates:

* Updated `UmbrellaDocs/action-linkspector` from `v1.3.1` to `v1.3.2` for checking Markdown links.
* Updated `extractions/setup-just` from `v2` to `v3` for setting up Just.
* Updated `astral-sh/setup-uv` from `v5.3.1` to `v5.4.0` for installing the latest version of uv. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L85-R93) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L108-R108)
* Updated `github/codeql-action/upload-sarif` from `v3.28.11` to `v3.28.13` for uploading SARIF files.
* Updated `github/codeql-action/init` and `github/codeql-action/analyze` from `v3.28.11` to `v3.28.13` for initializing and performing CodeQL analysis.