### PR TITLE
Update Security Alerts Threshold Level

### DIFF
--- a/modules/default-branch-protection/rules.tf
+++ b/modules/default-branch-protection/rules.tf
@@ -51,7 +51,7 @@ resource "github_repository_ruleset" "default_ruleset" {
         content {
           tool                      = required_code_scanning_tool.value
           alerts_threshold          = "all"
-          security_alerts_threshold = "critical"
+          security_alerts_threshold = "high"
         }
       }
     }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `modules/default-branch-protection/rules.tf` file to adjust the security alerts threshold for the default ruleset.

Security alerts threshold adjustment:

* [`modules/default-branch-protection/rules.tf`](diffhunk://#diff-4dedf3b9da1a018aab107c0736c07f13b68ed197d6f7f8d69239b45b92f17448L54-R54): Changed the `security_alerts_threshold` from "critical" to "high" in the `github_repository_ruleset` resource.
