### PR TITLE
Update aws-timing-scripts Status Checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -48,6 +48,7 @@ module "aws-timing-scripts_default_branch_protection" {
     "CodeQL Analysis (python)",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
     "Run CodeLimit",
     "Run Python Code Checks",
   ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/aws-timing-scripts.tf` file. The change adds a new step, "Lefthook Validate", to the list of actions in the `aws-timing-scripts_default_branch_protection` module.

* [`stack/aws-timing-scripts.tf`](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceR51): Added "Lefthook Validate" to the list of actions in the `aws-timing-scripts_default_branch_protection` module.