### PR TITLE
Fix Security Alerts Threshold Level

### DIFF
--- a/modules/default-branch-protection/rules.tf
+++ b/modules/default-branch-protection/rules.tf
@@ -51,7 +51,7 @@ resource "github_repository_ruleset" "default_ruleset" {
         content {
           tool                      = required_code_scanning_tool.value
           alerts_threshold          = "all"
-          security_alerts_threshold = "high"
+          security_alerts_threshold = "high_or_higher"
         }
       }
     }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `modules/default-branch-protection/rules.tf` file to update the security alerts threshold for the default ruleset.

* [`modules/default-branch-protection/rules.tf`](diffhunk://#diff-4dedf3b9da1a018aab107c0736c07f13b68ed197d6f7f8d69239b45b92f17448L54-R54): Changed `security_alerts_threshold` from "high" to "high_or_higher" in the `github_repository_ruleset` resource.