### PR TITLE
Update python-practice Status Checks

### DIFF
--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -51,6 +51,7 @@ module "python-practise_default_branch_protection" {
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",
     "Dependency Review",
+    "Lefthook Validate",
     "Label Pull Request",
     "Run Python Code Checks",
     "Run Unit Tests",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `stack/python-practise.tf` file. The change adds a new validation step to the default branch protection rules.

* [`stack/python-practise.tf`](diffhunk://#diff-fc110097cfb0503bf0fed5f3d3998731b426ace7a06d573b182e31126ca3ecebR54): Added "Lefthook Validate" to the list of required status checks for branch protection.