### PR TITLE
Add SlocCount repository description

### DIFF
--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -2,7 +2,7 @@ resource "github_repository" "SlocCount" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name        = "SlocCount"
-  description = ""
+  description = "A repository to count the lines of code in a project"
   visibility  = "public"
 
   # Repository Features


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `stack/SlocCount.tf` file, where the description of the `github_repository` resource has been updated to provide more context about the repository.

* [`stack/SlocCount.tf`](diffhunk://#diff-d739447262e9ffe0d94173aa0fbecf900d26abd606d622fa121f67b5cbc87936L5-R5): Updated the `description` field for the `github_repository` resource to "A repository to count the lines of code in a project" to provide a clearer explanation of the repository's purpose.