### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -127,6 +127,5 @@ jobs:
         with:
           languages: actions
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the use of a custom CodeQL configuration file and simplifies the CodeQL analysis setup in the GitHub Actions workflow.

**CodeQL configuration changes:**

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Deleted the query filter that excluded the `actions/unpinned-tag` query.

**GitHub Actions workflow updates:**

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L130): Removed the `config-file` parameter from the CodeQL analysis setup, which previously referenced the deleted custom configuration file.