### PR TITLE
Update github-stats-analyser status checks

### DIFF
--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -53,6 +53,7 @@ module "github-stats-analyser_default_branch_protection" {
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",
     "Dependency Review",
+    "Pinact Verify",
     "Label Pull Request",
     "Lefthook Validate",
     "Run CodeLimit",


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new required status check to the default branch protection rules in the `github-stats-analyser` module.

Branch protection updates:

* [`stack/github-stats-analyser.tf`](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bR56): Added `"Pinact Verify"` as a required status check in the `github-stats-analyser_default_branch_protection` module.