### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.2
+        uses: UmbrellaDocs/action-linkspector@49cf4f8da82db70e691bb8284053add5028fa244 # v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -20,7 +20,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the references for various GitHub Actions in workflow files to use specific commit SHAs instead of version tags. This ensures that the workflows use fixed versions of the actions, improving reproducibility and security.

### Updates to GitHub Actions in `.github/workflows/code-checks.yml`:

* Updated `super-linter/super-linter/slim` action to commit `4e8a7c2bf106c4c766c816b35ec612638dc9b6b2` (previously `v7.3.0`).
* Updated `UmbrellaDocs/action-linkspector` action to commit `49cf4f8da82db70e691bb8284053add5028fa244` (previously `v1.3.2`).
* Updated `extractions/setup-just` action to commit `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` (previously `v3`).
* Updated `astral-sh/setup-uv` action to commit `22695119d769bdb6f7032ad67b9bca0ef8c4a174` (previously `v5.4.0`).

### Updates to GitHub Actions in other workflow files:

* Updated `pascalgn/size-label-action` in `.github/workflows/pull-request-tasks.yml` to commit `f8edde36b3be04b4f65dcfead05dc8691b374348` (previously `v0.5.5`).
* Updated `micnncim/action-label-syncer` in `.github/workflows/sync-labels.yml` to commit `3abd5ab72fda571e69fffd97bd4e0033dd5f495c` (previously `v1.3.0`).