### PR TITLE
Enforce All Repository Security Alerts

### DIFF
--- a/modules/default-branch-protection/rules.tf
+++ b/modules/default-branch-protection/rules.tf
@@ -51,7 +51,7 @@ resource "github_repository_ruleset" "default_ruleset" {
         content {
           tool                      = required_code_scanning_tool.value
           alerts_threshold          = "all"
-          security_alerts_threshold = "high_or_higher"
+          security_alerts_threshold = "all"
         }
       }
     }


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `security_alerts_threshold` setting in the default branch protection module to ensure stricter security standards.

Security configuration update:

* [`modules/default-branch-protection/rules.tf`](diffhunk://#diff-4dedf3b9da1a018aab107c0736c07f13b68ed197d6f7f8d69239b45b92f17448L54-R54): Changed the `security_alerts_threshold` value in the `github_repository_ruleset` resource from `high_or_higher` to `all`, requiring all security alerts to be addressed instead of only high-severity ones.