### PR TITLE
Pinact Check Job

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -129,3 +129,17 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13
+
+  pinact-verify:
+    name: Pinact Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"

--- a/Justfile
+++ b/Justfile
@@ -71,6 +71,18 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.3
+min_version: 1.11.11
 colors: true
 
 output:
@@ -20,3 +20,5 @@ pre-commit:
       run: just zizmor-check
     Tofu Format Checks:
       run: just tofu-fmt-check
+    Pinact Checks:
+      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces configuration and workflow updates to integrate and verify the use of Pinact, a tool for managing pinned dependencies, as well as minor updates to existing configurations. Below is a breakdown of the most important changes:

### Pinact Integration:

* Added a new Pinact configuration file `.github/other-configurations/pinact.yml` to define the version and specify actions to ignore (`actions/.*` and `github/codeql-action/.*`).
* Updated `Justfile` to include new commands for running and verifying Pinact (`pinact-run` and `pinact-check`).
* Modified `lefthook.yml` to add a new pre-commit hook (`Pinact Checks`) that runs the `pinact-check` command.

### Workflow Updates:

* Added a new `pinact-verify` job to `.github/workflows/code-checks.yml` to verify Pinact configurations. This job includes steps for checking out the repository and installing the latest version of `uv`.
* Updated the `uv` installation step in the existing workflow to use a specific commit hash instead of a version tag for better reproducibility.

### Configuration Updates:

* Increased the `lefthook` minimum version in `lefthook.yml` from `1.11.3` to `1.11.11` to ensure compatibility with the new hooks.