### PR TITLE
Update useful-commands status checks

### DIFF
--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -36,6 +36,7 @@ module "useful-commands_default_branch_protection" {
     "CodeQL Analysis",
     "Dependency Review",
     "Label Pull Request",
+    "Pinact Verify",
   ]
   required_code_scanning_tools = ["CodeQL", "zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new required status check to the default branch protection configuration in the `useful-commands` stack.

* [`stack/useful-commands.tf`](diffhunk://#diff-66628c93f78b671ea7f168606ef7642b16e24c99615b28680ec3d9f01a9106b0R39): Added `"Pinact Verify"` to the list of required status checks under the `useful-commands_default_branch_protection` module.