### PR TITLE
Update RepoSync status checks

### DIFF
--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -47,6 +47,7 @@ module "RepoSync_default_branch_protection" {
     "Dependency Review",
     "Label Pull Request",
     "Lefthook Validate",
+    "Pinact Verify",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection settings in the `RepoSync` module to include an additional status check.

Branch protection updates:

* [`stack/RepoSync.tf`](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beR50): Added `"Pinact Verify"` to the list of required status checks in the `RepoSync_default_branch_protection` module.