### PR TITLE
Update source_scan status checks

### DIFF
--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -63,6 +63,7 @@ module "source_scan_default_branch_protection" {
     "CodeQL Analysis (python)",
     "Dependency Review",
     "Label Pull Request",
+    "Pinact Verify",
     "Run CodeLimit",
     "Run Python Code Checks",
     "Run Unit Tests",


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new required status check, "Pinact Verify," to the default branch protection rules for two modules in the Terraform configuration. This ensures that the "Pinact Verify" check must pass before changes can be merged.

Updates to default branch protection rules:

* [`stack/RepoSync.tf`](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beR50): Added "Pinact Verify" to the list of required status checks in the `RepoSync_default_branch_protection` module.
* [`stack/source_scan.tf`](diffhunk://#diff-4b3bf164059b483435d7002f084e05adc33a2a964754f30a5ebc79fa8489ee26R66): Added "Pinact Verify" to the list of required status checks in the `source_scan_default_branch_protection` module.
