### PR TITLE
Update github-pr-analyser status checks

### DIFF
--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -54,6 +54,8 @@ module "github-pr-analyser_default_branch_protection" {
     "CodeQL Analysis (go)",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
+    "Pinact Verify",
     "Run Go Vulnerability Check",
     "Run Local Action",
     "Run Unit Tests",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the branch protection rules in the `github-pr-analyser.tf` file to include additional required checks for pull requests.

### Updates to branch protection rules:
* [`stack/github-pr-analyser.tf`](diffhunk://#diff-432bae1b13646e0510fa8807f1fcf29e9bb903141c00a6f1958c3ae7df2c16f7R57-R58): Added "Lefthook Validate" and "Pinact Verify" to the list of required status checks for the `github-pr-analyser_default_branch_protection` module.