### PR TITLE
Update useful-commands status checks

### DIFF
--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -36,7 +36,6 @@ module "useful-commands_default_branch_protection" {
     "CodeQL Analysis",
     "Dependency Review",
     "Label Pull Request",
-    "Pinact Verify",
   ]
   required_code_scanning_tools = ["CodeQL", "zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the `stack/useful-commands.tf` file by removing the "Pinact Verify" workflow from the list of required status checks in the `useful-commands_default_branch_protection` module.