### PR TITLE
Update RepoOrchestrator status checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -129,17 +129,3 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -48,7 +48,6 @@ module "RepoOrchestrator_default_branch_protection" {
     "Dependency Review",
     "Label Pull Request",
     "Lefthook Validate",
-    "Pinact Verify",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the deprecated "Pinact Verify" workflow and updates the associated configurations to reflect this change.

### Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L132-L145): Removed the "Pinact Verify" job, which included steps for repository checkout and installing the latest version of `uv`.

### Configuration updates:

* [`stack/RepoOrchestrator.tf`](diffhunk://#diff-91f35e38e4fb154b436ffff883598acbcd0280c0516ddbbfa24d768525b9e306L51): Removed "Pinact Verify" from the list of required status checks in the `RepoOrchestrator_default_branch_protection` module.