### PR TITLE
Update source_scan status checks

### DIFF
--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -63,7 +63,6 @@ module "source_scan_default_branch_protection" {
     "CodeQL Analysis (python)",
     "Dependency Review",
     "Label Pull Request",
-    "Pinact Verify",
     "Run CodeLimit",
     "Run Python Code Checks",
     "Run Unit Tests",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules by removing an outdated workflow from the required checks in the `source_scan.tf` file.

Branch protection updates:

* [`stack/source_scan.tf`](diffhunk://#diff-4b3bf164059b483435d7002f084e05adc33a2a964754f30a5ebc79fa8489ee26L66): Removed the `Pinact Verify` workflow from the list of required status checks in the `source_scan_default_branch_protection` module.