### PR TITLE
Update RepoSync status checks

### DIFF
--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -47,7 +47,6 @@ module "RepoSync_default_branch_protection" {
     "Dependency Review",
     "Label Pull Request",
     "Lefthook Validate",
-    "Pinact Verify",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small adjustment to the `stack/RepoSync.tf` file by removing the "Pinact Verify" check from the list of required status checks for the `RepoSync_default_branch_protection` module.

* [`stack/RepoSync.tf`](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beL50): Removed "Pinact Verify" from the list of required status checks in the `RepoSync_default_branch_protection` module.