### PR TITLE
Update github-pr-analyser status checks

### DIFF
--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -55,7 +55,6 @@ module "github-pr-analyser_default_branch_protection" {
     "Dependency Review",
     "Label Pull Request",
     "Lefthook Validate",
-    "Pinact Verify",
     "Run Go Vulnerability Check",
     "Run Local Action",
     "Run Unit Tests",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the `stack/github-pr-analyser.tf` file by removing the `"Pinact Verify"` step from the list of actions in the `github-pr-analyser_default_branch_protection` module.