### PR TITLE
Update github-stats-analyser status checks

### DIFF
--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -55,7 +55,6 @@ module "github-stats-analyser_default_branch_protection" {
     "Dependency Review",
     "Label Pull Request",
     "Lefthook Validate",
-    "Pinact Verify",
     "Run CodeLimit",
     "Run Local Action",
     "Run Python Code Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `stack/github-stats-analyser.tf` file by removing the "Pinact Verify" workflow from the list of default branch protection checks, likely as part of a cleanup or deprecation effort.

* [`stack/github-stats-analyser.tf`](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bL58): Removed "Pinact Verify" from the list of required branch protection workflows in the `github-stats-analyser_default_branch_protection` module.