### PR TITLE
Add project-links repository

### DIFF
--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -1,0 +1,48 @@
+resource "github_repository" "project-links" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name         = "project-links"
+  description  = ""
+  visibility   = "public"
+  homepage_url = "https://jackplowman.github.io/project-links/"
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+
+  # GitHub Pages settings
+  pages {
+    build_type = "workflow"
+    source {
+      branch = "main"
+      path   = "/"
+    }
+  }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new Terraform resource to manage a GitHub repository configuration for the `project-links` project. The changes include repository settings, security configurations, GitHub Pages setup, and template usage.

### Repository Configuration:
* Added a new `github_repository` resource to define the `project-links` repository with settings such as `visibility`, `homepage_url`, and pull request rules (e.g., enabling auto-merge and branch deletion on merge).

### Security Enhancements:
* Enabled `secret_scanning` and `secret_scanning_push_protection` to enhance repository security by detecting and preventing sensitive data exposure.

### GitHub Pages Setup:
* Configured GitHub Pages to use the `main` branch as the source with a workflow build type.

### Template Usage:
* Applied a repository template from `JackPlowman/repository-template` for initial setup, excluding all branches except the default.