### PR TITLE
Add project-links dependabot security updates

### DIFF
--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -46,3 +46,8 @@ resource "github_repository" "project-links" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "project-links" {
+  repository = github_repository.project-links.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new resource to enable Dependabot security updates for the `project-links` GitHub repository.

* **Dependabot Security Updates**:
  * Added a new `github_repository_dependabot_security_updates` resource in `stack/project-links.tf` to enable Dependabot security updates for the `project-links` repository.
