### PR TITLE
Add project-links status checks

### DIFF
--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -51,3 +51,27 @@ resource "github_repository_dependabot_security_updates" "project-links" {
   repository = github_repository.project-links.name
   enabled    = true
 }
+
+module "project-links_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.project-links.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Justfile Format",
+    "Check Markdown links",
+    "Check Pull Request Title",
+    "CodeQL Analysis (actions)",
+    "CodeQL Analysis (python)",
+    "CodeQL Analysis (typescript)",
+    "Dependency Review",
+    "Label Pull Request",
+    "Run CodeLimit",
+    "Run Python Test Code Checks",
+    "Run TypeScript Code Checks",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint"]
+
+  depends_on = [github_repository.project-links]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a module for default branch protection to the `project-links` repository in the Terraform configuration. The most important change is the addition of the `project-links_default_branch_protection` module with required status checks and code scanning tools.

### Addition of default branch protection:

* **New module for branch protection**: Added a `project-links_default_branch_protection` module to enforce default branch protection rules. This includes specifying required status checks (e.g., "Check Code Quality", "Run Python Test Code Checks") and required code scanning tools (e.g., "zizmor", "CodeQL"). The module depends on the `project-links` repository resource. (`stack/project-links.tf`, [stack/project-links.tfR54-R77](diffhunk://#diff-8d4a200df5e9c4325ae12ffba43bb709aed7403c35680e7b6b89e058fa1f37aeR54-R77))