### PR TITLE
Add project-links description

### DIFF
--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -2,7 +2,7 @@ resource "github_repository" "project-links" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name         = "project-links"
-  description  = ""
+  description  = "A collection of links to my projects"
   visibility   = "public"
   homepage_url = "https://jackplowman.github.io/project-links/"
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `description` field of the `github_repository` resource in the Terraform configuration file to provide a meaningful description for the repository.

* [`stack/project-links.tf`](diffhunk://#diff-8d4a200df5e9c4325ae12ffba43bb709aed7403c35680e7b6b89e058fa1f37aeL5-R5): Changed the `description` field from an empty string to `"A collection of links to my projects"` in the `github_repository` resource.