### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
     directories:
       - "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,9 +21,8 @@ updates:
       - "/stack"
       - "/modules/default-branch-protection"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       terraform:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to switch from a daily schedule to a cron-based schedule for dependency updates.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R9): Changed the `schedule` for updates from a daily interval with a specific time and timezone to a cronjob schedule (`30 7,12,17 * * *`) for both the root directory and specific subdirectories like `/stack` and `/modules/default-branch-protection`. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R9) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L25-R25)