### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       - "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,7 +22,7 @@ updates:
       - "/modules/default-branch-protection"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       terraform:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to simplify the cron schedule for dependency updates. The most important changes involve modifying the `cronjob` schedules for specific update paths.

Dependabot configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R9): Updated the `cronjob` schedule for the root directory (`"/"`) to run only at 7:30 AM daily instead of three times a day.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L25-R25): Updated the `cronjob` schedule for the `"/modules/default-branch-protection"` path to run only at 7:30 AM daily instead of three times a day.
