### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,19 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -23,9 +26,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       terraform:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration file to optimize Dependabot's behavior for managing dependencies. The most important changes include consolidating the directory specification, adding timezone support for scheduling, and refining group configurations with new attributes and exclusions.

### Dependabot configuration updates:

* Consolidated the directory specification by replacing the `directories` array with a single `directory` field for simplicity. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Added a `timezone` field (`Europe/London`) to the schedule configuration to ensure cron jobs run at the correct local time. (`[[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`, `[[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R29-R33)`)

### Group configuration refinements:

* Introduced the `applies-to` attribute (`version-updates`) to both `github-actions` and `terraform` groups for better targeting of updates. (`[[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`, `[[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R29-R33)`)
* Added an `exclude-patterns` field to the `github-actions` group to exclude updates matching `super-linter/*`. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)