### PR TITLE
Update repo_standards_validator status checks

### DIFF
--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -53,6 +53,7 @@ module "repo_standards_validator_default_branch_protection" {
     "CodeQL Analysis (python)",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
     "Run CodeLimit",
     "Run Local Action",
     "Run Python Code Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new validation step to the repository standards validator. The most important change is the inclusion of the "Lefthook Validate" step in the default branch protection rules.

* **Enhancements to repository standards validation:**
  * [`stack/repo_standards_validator.tf`](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cR56): Added "Lefthook Validate" as a required check in the `repo_standards_validator_default_branch_protection` module.