### PR TITLE
Update repo-overseer status checks

### DIFF
--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -64,6 +64,7 @@ module "repo-overseer_default_branch_protection" {
     "CodeQL Analysis (typescript)",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
     "Run CodeLimit",
     "Run Python Code Checks",
     "Run TypeScript Code Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `repo-overseer_default_branch_protection` module to include an additional required status check for branch protection.

* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aR67): Added `"Lefthook Validate"` to the list of required status checks for the `repo-overseer_default_branch_protection` module.