### PR TITLE
Update github-stats status checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -63,7 +63,6 @@ module "github-stats_default_branch_protection" {
     "CodeQL Analysis (python)",
     "CodeQL Analysis (typescript)",
     "Dependency Review",
-    "Docker Build Test",
     "Label Pull Request",
     "Lefthook Validate",
     "Run CodeLimit",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor adjustment to the branch protection rules in the `stack/github-stats.tf` file by removing the "Docker Build Test" check from the list of required status checks.

* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1L66): Removed "Docker Build Test" from the required status checks in the `github-stats_default_branch_protection` module.