### PR TITLE
Update status-sentinel status checks

### DIFF
--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -64,6 +64,7 @@ module "status-sentinel_default_branch_protection" {
     "CodeQL Analysis (typescript)",
     "Dependency Review",
     "Label Pull Request",
+    "Lefthook Validate",
     "Run CodeLimit",
     "Run Python Code Checks",
     "Run TypeScript Code Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new validation step to the default branch protection rules in the `status-sentinel.tf` file.

* [`stack/status-sentinel.tf`](diffhunk://#diff-0a754bed0bccffa46d2be5cda18d1855448c8dc58b211c3dfc8ebec894f2569fR67): Added `"Lefthook Validate"` to the list of required status checks for the default branch protection module.