### PR TITLE
Add reusable-workflows repository

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -1,0 +1,37 @@
+resource "github_repository" "reusable-workflows" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name        = "reusable-workflows"
+  description = ""
+  visibility  = "public"
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub repository resource definition in the Terraform configuration file `stack/reusable-workflows.tf`. The resource is configured with specific repository settings, security features, and a template repository.

### Addition of a new GitHub repository resource:

* **Repository creation**: Added a new `github_repository` resource named `reusable-workflows` with `public` visibility and an empty description.
* **Pull request settings**: Configured pull request settings to allow auto-merge, disallow merge and rebase commits, enable branch updates, delete branches on merge, and set squash merge commit message and title formats.
* **Other repository settings**: Disabled downloads, enabled vulnerability alerts, and required web commit signoffs.
* **Security settings**: Enabled secret scanning and secret scanning push protection under `security_and_analysis`.
* **Template repository**: Configured the repository to use `JackPlowman/repository-template` as a template, excluding all branches.