### PR TITLE
Add reusable-workflows dependabot security updates

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -35,3 +35,8 @@ resource "github_repository" "reusable-workflows" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "reusable-workflows" {
+  repository = github_repository.reusable-workflows.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new resource to enable Dependabot security updates for the `reusable-workflows` repository in the Terraform configuration.

* [`stack/reusable-workflows.tf`](diffhunk://#diff-7798ff67e4824cab3b5573524834853721910d9747a8e41a30fa895206636e86R38-R42): Added a `github_repository_dependabot_security_updates` resource to ensure Dependabot security updates are enabled for the `reusable-workflows` repository.