### PR TITLE
Add reusable-workflows status checks

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -40,3 +40,21 @@ resource "github_repository_dependabot_security_updates" "reusable-workflows" {
   repository = github_repository.reusable-workflows.name
   enabled    = true
 }
+
+module "reusable-workflows_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.reusable-workflows.name
+  required_status_checks = [
+    "Check Code Quality",
+    "Check GitHub Actions with zizmor",
+    "Check Markdown links",
+    "CodeQL Analysis",
+    "Dependency Review",
+    "Label Pull Request",
+    "Lefthook Validate",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.reusable-workflows]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module to enforce default branch protection rules for the `reusable-workflows` repository in the Terraform configuration. The changes ensure that specific status checks and code scanning tools are required for the repository's default branch.

### New module for branch protection:

* [`stack/reusable-workflows.tf`](diffhunk://#diff-7798ff67e4824cab3b5573524834853721910d9747a8e41a30fa895206636e86R43-R60): Added a `module` block named `reusable-workflows_default_branch_protection` that sources the `default-branch-protection` module. This enforces branch protection rules on the `reusable-workflows` repository, specifying required status checks (e.g., "Check Code Quality", "CodeQL Analysis") and required code scanning tools ("zizmor", "CodeQL").