### PR TITLE
Update reusable-workflows status checks

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -52,8 +52,8 @@ module "reusable-workflows_default_branch_protection" {
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",
     "Common Code Checks / Lefthook Validate",
-    "Dependency Review",
-    "Label Pull Request",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `reusable-workflows_default_branch_protection` module in `stack/reusable-workflows.tf` to align workflow names with a new naming convention. 

### Workflow naming updates:
* Renamed `"Dependency Review"` to `"Common Pull Request Tasks / Dependency Review"` to reflect the new naming structure.
* Renamed `"Label Pull Request"` to `"Common Pull Request Tasks / Label Pull Request"` for consistency with other workflow names.