### PR TITLE
Update DependabotTrigger status checks

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -52,14 +52,14 @@ module "DependabotTrigger_default_branch_protection" {
   repository_name = github_repository.DependabotTrigger.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
     "Dependency Review",
     "Label Pull Request",
-    "Lefthook Validate",
     "Run CodeLimit",
     "Run Python Code Checks",
   ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `DependabotTrigger_default_branch_protection` module in `stack/DependabotTrigger.tf` to align with changes in the naming conventions of required status checks. The changes ensure consistency and compatibility with the updated naming scheme.

### Updates to required status checks:
* Renamed several status checks to include the prefix `Common Code Checks /`, such as "Check GitHub Actions with zizmor," "Check Justfile Format," and "Check Markdown links."
* Added the "Common Code Checks / Lefthook Validate" status check, which was previously listed without the prefix.