### PR TITLE
Update RepoOrchestrator status checks

### DIFF
--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -41,13 +41,13 @@ module "RepoOrchestrator_default_branch_protection" {
   repository_name = github_repository.RepoOrchestrator.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
     "CodeQL Analysis",
     "Dependency Review",
     "Label Pull Request",
-    "Lefthook Validate",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the default branch protection in the `RepoOrchestrator` module to align with the new naming convention and include an additional check.

Updates to default branch protection:

* [`stack/RepoOrchestrator.tf`](diffhunk://#diff-91f35e38e4fb154b436ffff883598acbcd0280c0516ddbbfa24d768525b9e306L44-L50): Updated the names of several status checks to use the "Common Code Checks /" prefix and added a new check, "Common Code Checks / Lefthook Validate," to the list of required status checks. The standalone "Lefthook Validate" check was removed to avoid duplication.