### PR TITLE
Update repository-template status checks

### DIFF
--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -42,13 +42,13 @@ module "repository-template_default_branch_protection" {
   repository_name = github_repository.repository-template.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
     "Dependency Review",
     "Label Pull Request",
-    "Lefthook Validate",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules in the `repository-template` Terraform module to improve clarity and consistency in status check naming.

### Updates to branch protection rules:

* [`stack/repository-template.tf`](diffhunk://#diff-e423eafcab1924cdae12635150f2d1fbe733b23ad035d3f61dcf8ea5a1d4f4fbL45-L51): Renamed several required status checks to include the prefix "Common Code Checks" for improved clarity and organization. Specifically, checks for GitHub Actions, Justfile Format, Markdown links, and Lefthook Validate were updated.