### PR TITLE
Update project-link status checks

### DIFF
--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -58,12 +58,13 @@ module "project-links_default_branch_protection" {
   repository_name = github_repository.project-links.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",
     "CodeQL Analysis (typescript)",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
     "Dependency Review",
     "Label Pull Request",
     "Run CodeLimit",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules for the `project-links` repository. The main change involves standardizing the naming conventions for required status checks and adding a new validation step.

Updates to branch protection rules:

* [`stack/project-links.tf`](diffhunk://#diff-8d4a200df5e9c4325ae12ffba43bb709aed7403c35680e7b6b89e058fa1f37aeL61-R67): Renamed several required status checks to include the prefix "Common Code Checks /" for consistency. Specifically, updated "Check GitHub Actions with zizmor," "Check Justfile Format," and "Check Markdown links" to their prefixed versions.
* [`stack/project-links.tf`](diffhunk://#diff-8d4a200df5e9c4325ae12ffba43bb709aed7403c35680e7b6b89e058fa1f37aeL61-R67): Added a new required status check, "Common Code Checks / Lefthook Validate," to enforce validation using Lefthook.