### PR TITLE
Update RepoSync status checks

### DIFF
--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -41,12 +41,13 @@ module "RepoSync_default_branch_protection" {
   repository_name = github_repository.RepoSync.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Markdown links",
     "CodeQL Analysis",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
     "Dependency Review",
     "Label Pull Request",
-    "Lefthook Validate",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules in the `RepoSync` module to align with a new naming convention and include additional checks.

### Updates to branch protection rules:

* Updated the naming convention for status checks by prefixing them with `Common Code Checks /`. For example, `"Check GitHub Actions with zizmor"` was renamed to `"Common Code Checks / Check GitHub Actions with zizmor"`. (`stack/RepoSync.tf` [stack/RepoSync.tfL44-L49](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beL44-L49))
* Added new status checks: `"Common Code Checks / Check Justfile Format"` and `"Common Code Checks / Lefthook Validate"`. (`stack/RepoSync.tf` [stack/RepoSync.tfL44-L49](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beL44-L49))
* Removed redundant or outdated checks, such as `"Check Markdown links"` and `"Lefthook Validate"`, to avoid duplication under the new naming convention. (`stack/RepoSync.tf` [stack/RepoSync.tfL44-L49](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beL44-L49))