### PR TITLE
Update SlocCount status checks

### DIFF
--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -46,14 +46,14 @@ module "SlocCount_default_branch_protection" {
   repository_name = github_repository.SlocCount.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
     "Dependency Review",
     "Label Pull Request",
-    "Lefthook Validate",
     "Run CodeLimit",
     "Run Diagrams Python Code Checks",
     "Run Scanner Python Code Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules in the `SlocCount` module to align with a new naming convention for status checks and includes the addition of a previously omitted check.

### Updates to branch protection rules:

* Renamed several status checks to follow the new "Common Code Checks" naming convention, such as `"Check GitHub Actions with zizmor"` to `"Common Code Checks / Check GitHub Actions with zizmor"`.
* Added the `"Common Code Checks / Lefthook Validate"` status check, which was previously missing from the branch protection rules.