### PR TITLE
Update aws-timing-scripts status checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -41,14 +41,14 @@ module "aws-timing-scripts_default_branch_protection" {
   repository_name = github_repository.aws-timing-scripts.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (python)",
-    "Dependency Review",
-    "Label Pull Request",
-    "Lefthook Validate",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
     "Run CodeLimit",
     "Run Python Code Checks",
   ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the `aws-timing-scripts` repository to align with a new naming convention for checks. The changes ensure consistency and better organization of status checks.

### Updates to required status checks:
* Renamed several status checks to include a prefix indicating their category, such as "Common Code Checks" or "Common Pull Request Tasks." This affects checks like "Check GitHub Actions with zizmor," "Check Justfile Format," and "Dependency Review," among others. (`stack/aws-timing-scripts.tf`, [stack/aws-timing-scripts.tfL44-R51](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceL44-R51))