### PR TITLE
Update useful-commands status checks

### DIFF
--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -30,12 +30,13 @@ module "useful-commands_default_branch_protection" {
   repository_name = github_repository.useful-commands.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis",
-    "Dependency Review",
-    "Label Pull Request",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
   ]
   required_code_scanning_tools = ["CodeQL", "zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection settings for the `useful-commands` repository in the `stack/useful-commands.tf` file. The changes primarily involve reorganizing and renaming required status checks to align with a new naming convention.

### Updates to default branch protection:

* Renamed several required status checks to use a more structured naming convention, grouping them under categories like "Common Code Checks" and "Common Pull Request Tasks." For example:
  - `"Check GitHub Actions with zizmor"` was renamed to `"Common Code Checks / Check GitHub Actions with zizmor"`.
  - `"Dependency Review"` was renamed to `"Common Pull Request Tasks / Dependency Review"`.
* Added a new required status check: `"Common Code Checks / Lefthook Validate"`.