### PR TITLE
Update development-environment status checks

### DIFF
--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -41,13 +41,13 @@ module "development-environment_default_branch_protection" {
   repository_name = github_repository.development-environment.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis",
-    "Dependency Review",
-    "Label Pull Request",
-    "Lefthook Validate",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules for the `development-environment` repository in the Terraform configuration. The changes primarily involve renaming and organizing the required status checks to align with a new naming convention.

### Updates to branch protection rules:

* [`stack/development-environment.tf`](diffhunk://#diff-00e2788c3b7e75485d7bb7a91b33585cd0412f41347a3c045135761b660ad7a5L44-R50): Renamed several required status checks to include prefixes like "Common Code Checks" and "Common Pull Request Tasks" for better organization and clarity. For example, "Check GitHub Actions with zizmor" was renamed to "Common Code Checks / Check GitHub Actions with zizmor."