### PR TITLE
Update TechScanner status checks

### DIFF
--- a/stack/TechScanner.tf
+++ b/stack/TechScanner.tf
@@ -51,12 +51,13 @@ module "TechScanner_default_branch_protection" {
   repository_name = github_repository.TechScanner.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis",
-    "Dependency Review",
-    "Label Pull Request",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
   ]
   required_code_scanning_tools = ["CodeQL", "zizmor"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the branch protection rules for the `TechScanner` repository in `stack/TechScanner.tf`. The changes primarily involve reorganizing and renaming the required status checks to align with a standardized naming convention.

### Updates to branch protection rules:

* Renamed several status checks to follow a "Common Code Checks" or "Common Pull Request Tasks" naming pattern for better organization and clarity. For example:
  - `"Check GitHub Actions with zizmor"` is now `"Common Code Checks / Check GitHub Actions with zizmor"`.
  - `"Dependency Review"` is now `"Common Pull Request Tasks / Dependency Review"`.

* Added a new status check: `"Common Code Checks / Lefthook Validate"`.