### PR TITLE
Update actions-status status checks

### DIFF
--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -52,11 +52,15 @@ module "actions-status_default_branch_protection" {
   repository_name = github_repository.actions-status.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
-    "Dependency Review",
-    "Label Pull Request",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+    "Check Pull Request Title",
+    "CodeQL Analysis (actions)",
+    "CodeQL Analysis (typescript)",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the `actions-status_default_branch_protection` module in `stack/actions-status.tf`. The changes primarily involve renaming and reorganizing the status checks to align with a new naming convention and adding a few new checks.

### Updates to required status checks:

* Renamed existing checks to include prefixes like `Common Code Checks` and `Common Pull Request Tasks`, improving clarity and grouping. For example, `"Check GitHub Actions with zizmor"` is now `"Common Code Checks / Check GitHub Actions with zizmor"`.
* Added new status checks: `"Common Code Checks / Lefthook Validate"`, `"Check Pull Request Title"`, `"CodeQL Analysis (actions)"`, and `"CodeQL Analysis (typescript)"`. These enhance the validation process for pull requests.