### PR TITLE
Update create-repository-tasks status checks

### DIFF
--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -41,13 +41,13 @@ module "create-repository-tasks_default_branch_protection" {
   repository_name = github_repository.create-repository-tasks.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis",
-    "Dependency Review",
-    "Label Pull Request",
-    "Lefthook Validate",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules in the Terraform configuration for repository creation tasks. The changes primarily involve renaming and reorganizing required status checks to align with a new naming convention.

Updates to default branch protection rules:

* [`stack/create-repository-tasks.tf`](diffhunk://#diff-0c65d623333b07f372a64d80bfdae6e2460a61e8634b185074d2800d1d167ceeL44-R50): Updated the `required_status_checks` list to use a new naming convention that groups checks under categories like "Common Code Checks" and "Common Pull Request Tasks". For example, "Check GitHub Actions with zizmor" is now "Common Code Checks / Check GitHub Actions with zizmor".
