### PR TITLE
Update repository-visualiser status checks

### DIFF
--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -51,14 +51,14 @@ module "repository-visualiser_default_branch_protection" {
   repository_name = github_repository.repository-visualiser.name
   required_status_checks = [
     "Check Code Quality",
-    "Check GitHub Actions with zizmor",
-    "Check Justfile Format",
-    "Check Markdown links",
     "CodeQL Analysis (actions)",
     "CodeQL Analysis (go)",
-    "Dependency Review",
-    "Label Pull Request",
-    "Lefthook Validate",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
     "Repository Visualiser",
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the `repository-visualiser_default_branch_protection` module in `stack/repository-visualiser.tf`. The changes include renaming and reorganizing status checks to align with a new categorization scheme.

### Updates to required status checks:
* Renamed several status checks to include prefixes like `Common Code Checks` and `Common Pull Request Tasks` for better organization. Examples include:
  - `"Check GitHub Actions with zizmor"` renamed to `"Common Code Checks / Check GitHub Actions with zizmor"`.
  - `"Dependency Review"` renamed to `"Common Pull Request Tasks / Dependency Review"`.