### PR TITLE
Update Dependabot for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
           - "*"
         exclude-patterns:
           - "super-linter/super-linter"
-          - "JackPlowman/reusable-workflows/*"
+          - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor change to the `.github/dependabot.yml` file. The change updates the exclude pattern for dependencies to remove the wildcard from the `JackPlowman/reusable-workflows` path, ensuring the entire directory is excluded instead of just its contents.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L18-R18): Modified the exclude pattern for `JackPlowman/reusable-workflows` by removing the trailing wildcard (`*`).