### PR TITLE
Add projects status checks

### DIFF
--- a/stack/projects.tf
+++ b/stack/projects.tf
@@ -40,3 +40,22 @@ resource "github_repository_dependabot_security_updates" "projects" {
   repository = github_repository.projects.name
   enabled    = true
 }
+
+module "projects_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.projects.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.projects]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a module for default branch protection in the `stack/projects.tf` file. The most significant change is the addition of a new `projects_default_branch_protection` module to enforce branch protection rules for the `projects` repository.

### Branch protection configuration:
* Added a `module "projects_default_branch_protection"` to enforce default branch protection rules for the `projects` repository. This includes specifying required status checks (e.g., "Check Code Quality", "CodeQL Analysis") and required code scanning tools ("zizmor", "CodeQL"). The module depends on the `github_repository.projects` resource. (`[stack/projects.tfR43-R61](diffhunk://#diff-b0a37de59757357b8080f1ff625c99785318d1e20d1679ea7caeeafc0a079774R43-R61)`)