### PR TITLE
Add projects repository description

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -2,7 +2,7 @@ resource "github_repository" "github-stats" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name         = "github-stats"
-  description  = "A Website to display my Repository Statistics"
+  description  = "Website to display my Repository Statistics"
   visibility   = "public"
   homepage_url = "https://jackplowman.github.io/github-stats/"
 

--- a/stack/projects.tf
+++ b/stack/projects.tf
@@ -2,7 +2,7 @@ resource "github_repository" "projects" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name        = "projects"
-  description = ""
+  description = "A repository to list my projects and their status"
   visibility  = "public"
 
   # Pull Request settings


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the descriptions of two GitHub repositories in Terraform configuration files to make them more descriptive and user-friendly.

Changes to repository descriptions:

* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1L5-R5): Updated the description of the `github-stats` repository to "Website to display my Repository Statistics" for improved clarity.
* [`stack/projects.tf`](diffhunk://#diff-b0a37de59757357b8080f1ff625c99785318d1e20d1679ea7caeeafc0a079774L5-R5): Added a description to the `projects` repository, specifying it as "A repository to list my projects and their status."