### PR TITLE
Update create-repository-tasks status checks

### DIFF
--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -41,7 +41,7 @@ module "create-repository-tasks_default_branch_protection" {
   repository_name = github_repository.create-repository-tasks.name
   required_status_checks = [
     "Check Code Quality",
-    "CodeQL Analysis",
+    "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules for the `create-repository-tasks` module to reflect a more specific naming convention for one of the required status checks.

### Updates to branch protection rules:
* [`stack/create-repository-tasks.tf`](diffhunk://#diff-0c65d623333b07f372a64d80bfdae6e2460a61e8634b185074d2800d1d167ceeL44-R44): Updated the `required_status_checks` list to replace `"CodeQL Analysis"` with the more specific `"CodeQL Analysis (actions) / Analyse code"`.