### PR TITLE
Update aws-timing-scripts status checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -41,8 +41,8 @@ module "aws-timing-scripts_default_branch_protection" {
   repository_name = github_repository.aws-timing-scripts.name
   required_status_checks = [
     "Check Code Quality",
-    "CodeQL Analysis (actions)",
-    "CodeQL Analysis (python)",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (python) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the branch protection rules for the `aws-timing-scripts` repository. The changes primarily involve renaming two status checks to include a more descriptive suffix.

Updates to branch protection rules:

* [`stack/aws-timing-scripts.tf`](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceL44-R45): Renamed the status checks `CodeQL Analysis (actions)` and `CodeQL Analysis (python)` to `CodeQL Analysis (actions) / Analyse code` and `CodeQL Analysis (python) / Analyse code`, respectively, for improved clarity.