### PR TITLE
Update reusable-workflows status checks

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -55,7 +55,7 @@ module "reusable-workflows_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor"]
 
   depends_on = [github_repository.reusable-workflows]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates branch protection rules in two Terraform files to align with recent changes in status checks and code scanning tools. The most significant changes involve modifying required status checks and removing a code scanning tool from the configuration.

Updates to branch protection rules:

* [`stack/projects.tf`](diffhunk://#diff-b0a37de59757357b8080f1ff625c99785318d1e20d1679ea7caeeafc0a079774L50-R50): Updated the name of the "CodeQL Analysis" status check to "CodeQL Analysis (actions) / Analyse code" in the `projects_default_branch_protection` module.
* [`stack/reusable-workflows.tf`](diffhunk://#diff-7798ff67e4824cab3b5573524834853721910d9747a8e41a30fa895206636e86L58-R58): Removed "CodeQL" from the list of `required_code_scanning_tools` in the `reusable-workflows_default_branch_protection` module.