### PR TITLE
Update repository-template status checks

### DIFF
--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -42,7 +42,7 @@ module "repository-template_default_branch_protection" {
   repository_name = github_repository.repository-template.name
   required_status_checks = [
     "Check Code Quality",
-    "CodeQL Analysis",
+    "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules in the `repository-template` Terraform module. The most important change is an update to the name of a required status check to align with its current naming convention.

Branch protection updates:

* [`stack/repository-template.tf`](diffhunk://#diff-e423eafcab1924cdae12635150f2d1fbe733b23ad035d3f61dcf8ea5a1d4f4fbL45-R45): Updated the required status check name from `"CodeQL Analysis"` to `"CodeQL Analysis (actions) / Analyse code"` to reflect the updated naming convention.
