### PR TITLE
Update github-stats status checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -56,9 +56,9 @@ module "github-stats_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check Pull Request Title",
-    "CodeQL Analysis (actions)",
-    "CodeQL Analysis (python)",
-    "CodeQL Analysis (typescript)",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (python) / Analyse code",
+    "CodeQL Analysis (typescript) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the default branch protection in the `github-stats.tf` file. The changes clarify the purpose of the `CodeQL Analysis` checks by appending a descriptive suffix.

### Updates to default branch protection:

* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1L59-R61): Updated the `CodeQL Analysis` checks to include a more descriptive suffix (`/ Analyse code`) for each language-specific check. This change improves clarity in the status checks list.