### PR TITLE
Update repo_standards_validator status checks

### DIFF
--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -46,8 +46,8 @@ module "repo_standards_validator_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check Pull Request Title",
-    "CodeQL Analysis (actions)",
-    "CodeQL Analysis (python)",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (python) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks in the `repo_standards_validator_default_branch_protection` module to improve clarity by including more descriptive labels for CodeQL analysis checks.

### Updates to required status checks:

* [`stack/repo_standards_validator.tf`](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cL49-R50): Updated the labels for CodeQL analysis checks to include the `/ Analyse code` suffix, making the purpose of these checks more explicit.