### PR TITLE
Update repo-overseer status checks

### DIFF
--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -56,9 +56,9 @@ module "repo-overseer_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "Check Pull Request Title",
-    "CodeQL Analysis (actions)",
-    "CodeQL Analysis (python)",
-    "CodeQL Analysis (typescript)",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (python) / Analyse code",
+    "CodeQL Analysis (typescript) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for default branch protection in two Terraform modules to include more descriptive names for CodeQL analysis checks.

Updates to required status checks:

* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aL59-R61): Updated the names of CodeQL analysis checks to include the suffix `/ Analyse code` for better clarity.
* [`stack/repo_standards_validator.tf`](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cL49-R50): Similarly updated the names of CodeQL analysis checks to include the suffix `/ Analyse code`.