### PR TITLE
Update repository-visualiser status checks

### DIFF
--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -51,8 +51,8 @@ module "repository-visualiser_default_branch_protection" {
   repository_name = github_repository.repository-visualiser.name
   required_status_checks = [
     "Check Code Quality",
-    "CodeQL Analysis (actions)",
-    "CodeQL Analysis (go)",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (go) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for default branch protection in two Terraform modules. The changes standardize the naming of CodeQL analysis checks by appending "/ Analyse code" to their descriptions.

Updates to default branch protection:

* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aL59-R61): Updated the `required_status_checks` list in the `repo-overseer_default_branch_protection` module to include the standardized naming for CodeQL analysis checks.
* [`stack/repository-visualiser.tf`](diffhunk://#diff-ce6778ad24df568bf231f7fefa425873c3c9de592ed6fc6799151f28999a17b7L54-R55): Updated the `required_status_checks` list in the `repository-visualiser_default_branch_protection` module to include the standardized naming for CodeQL analysis checks.