### PR TITLE
Update screenshot_mailinator_email status checks

### DIFF
--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -44,8 +44,8 @@ module "screenshot_mailinator_email_default_branch_protection" {
   repository_name = github_repository.screenshot_mailinator_email.name
   required_status_checks = [
     "Check Code Quality",
-    "CodeQL Analysis (actions)",
-    "CodeQL Analysis (python)",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (python) / Analyse code",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the branch protection rules in the `screenshot_mailinator_email` module to improve clarity and consistency in status check names.

### Updates to branch protection rules:

* `stack/screenshot_mailinator_email.tf`: Renamed two status checks to include the `/ Analyse code` suffix for better clarity:
  - `"CodeQL Analysis (actions)"` → `"CodeQL Analysis (actions) / Analyse code"`
  - `"CodeQL Analysis (python)"` → `"CodeQL Analysis (python) / Analyse code"`
