### PR TITLE
Add travel-map repository

### DIFF
--- a/stack/travel-map.tf
+++ b/stack/travel-map.tf
@@ -1,0 +1,51 @@
+resource "github_repository" "travel-map" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name         = "travel-map"
+  description  = ""
+  visibility   = "public"
+  homepage_url = "https://jackplowman.github.io/travel-map/"
+
+  # Repository Features
+  has_issues   = false
+  has_projects = false
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  # GitHub Pages settings
+  pages {
+    build_type = "workflow"
+    source {
+      branch = "main"
+      path   = "/"
+    }
+  }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new Terraform resource to manage a GitHub repository for the "travel-map" project. The configuration includes repository settings, security features, and GitHub Pages setup.

### Repository Management:
* Added a new `github_repository` resource in `stack/travel-map.tf` to create and manage the "travel-map" repository with specific settings, including public visibility, disabled issues and projects, and enabled branch deletion on merge.

### Security Features:
* Enabled `vulnerability_alerts`, `secret_scanning`, and `secret_scanning_push_protection` to enhance repository security.

### GitHub Pages:
* Configured GitHub Pages for the repository with a build type of "workflow" and the source set to the `main` branch.

### Repository Template:
* Configured the repository to use a template from "JackPlowman/repository-template" without including all branches.