### PR TITLE
Add travel-map Dependabot Security Updates

### DIFF
--- a/stack/travel-map.tf
+++ b/stack/travel-map.tf
@@ -49,3 +49,8 @@ resource "github_repository" "travel-map" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "travel-map" {
+  repository = github_repository.travel-map.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new resource configuration to enable Dependabot security updates for the `travel-map` repository in the Terraform configuration.

Key change:

* [`stack/travel-map.tf`](diffhunk://#diff-dba7d146a76bf53414543e541391304d6d74ad026827fbc7248305ed235e5373R52-R56): Added a `github_repository_dependabot_security_updates` resource to enable Dependabot security updates for the `travel-map` repository.