### PR TITLE
Add travel-map status checks

### DIFF
--- a/stack/travel-map.tf
+++ b/stack/travel-map.tf
@@ -54,3 +54,22 @@ resource "github_repository_dependabot_security_updates" "travel-map" {
   repository = github_repository.travel-map.name
   enabled    = true
 }
+
+module "travel-map_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.travel-map.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis (actions) / Analyse code",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.travel-map]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module for default branch protection in the `travel-map` repository. The module enforces specific branch protection rules, including required status checks and code scanning tools.

### Branch protection configuration:

* Added a `module "travel-map_default_branch_protection"` block in `stack/travel-map.tf` to configure default branch protection for the `travel-map` repository. This includes:
  - Specifying required status checks, such as "Check Code Quality" and "CodeQL Analysis."
  - Defining required code scanning tools: "zizmor" and "CodeQL."
  - Setting a dependency on the `github_repository.travel-map` resource to ensure proper execution order.