### PR TITLE
Update github-stats status checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -66,7 +66,10 @@ module "github-stats_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
     "Run CodeLimit",
-    "Run Python Code Checks",
+    "Run Python Tests Format Checks",
+    "Run Python Tests Lint Checks",
+    "Run Python Tests Lockfile Check",
+    "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
     "Test TypeScript Code",
   ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `stack/github-stats.tf` file to refine the tasks listed in the `github-stats_default_branch_protection` module. The most notable change is the replacement of a single Python code check task with a more granular set of Python test-related tasks.

Refinement of Python tasks:

* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1L69-R72): Replaced the generic "Run Python Code Checks" task with four specific tasks: "Run Python Tests Format Checks," "Run Python Tests Lint Checks," "Run Python Tests Lockfile Check," and "Run Python Tests Type Checks."