### PR TITLE
Update repo-overseer status checks

### DIFF
--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -66,7 +66,10 @@ module "repo-overseer_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
     "Run CodeLimit",
-    "Run Python Code Checks",
+    "Run Python Tests Format Checks",
+    "Run Python Tests Lint Checks",
+    "Run Python Tests Lockfile Check",
+    "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
   required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor"]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules in the Terraform configuration for the `repo-overseer` module. The changes focus on refining Python test checks and ensuring comprehensive code scanning requirements.

### Updates to Python test checks:
* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aL69-R72): Replaced the single "Run Python Code Checks" task with four specific tasks: "Run Python Tests Format Checks," "Run Python Tests Lint Checks," "Run Python Tests Lockfile Check," and "Run Python Tests Type Checks."

### Code scanning tools:
* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aL69-R72): Confirmed the required code scanning tools remain "CodeQL," "Ruff," and "zizmor" for consistent security and quality checks.