### PR TITLE
Remove all Code Limit status checks

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -59,7 +59,6 @@ module "DependabotTrigger_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Dead Code Checks",
     "Run Python Format Checks",
     "Run Python Lint Checks",

--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -65,7 +65,6 @@ module "SlocCount_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Scanner Dead Code Checks",
     "Run Python Scanner Format Checks",
     "Run Python Scanner Lint Checks",

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -49,7 +49,6 @@ module "aws-timing-scripts_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Dead Code Checks",
     "Run Python Format Checks",
     "Run Python Lint Checks",

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -55,7 +55,6 @@ module "github-stats-analyser_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Local Action",
     "Run Python Dead Code Checks",
     "Run Python Format Checks",

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -65,7 +65,6 @@ module "github-stats_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Tests Format Checks",
     "Run Python Tests Lint Checks",
     "Run Python Tests Lockfile Check",

--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -67,7 +67,6 @@ module "project-links_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Tests Format Checks",
     "Run Python Tests Lint Checks",
     "Run Python Tests Lockfile Check",

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -56,7 +56,6 @@ module "project-status-checker_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Local Project Status Checker Action",
     "Run Unit Tests",
     "Test GitHub Summary",

--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -65,7 +65,6 @@ module "repo-overseer_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Tests Format Checks",
     "Run Python Tests Lint Checks",
     "Run Python Tests Lockfile Check",

--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -54,7 +54,6 @@ module "repo_standards_validator_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Local Action",
     "Run Python Format Checks",
     "Run Python Lint Checks",

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -52,7 +52,6 @@ module "screenshot_mailinator_email_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Dead Code Checks",
     "Run Python Format Checks",
     "Run Python Lint Checks",

--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -64,7 +64,6 @@ module "source_scan_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Dead Code Checks",
     "Run Python Format Checks",
     "Run Python Lint Checks",

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -65,7 +65,6 @@ module "status-sentinel_default_branch_protection" {
     "Common Code Checks / Lefthook Validate",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
-    "Run CodeLimit",
     "Run Python Tests Format Checks",
     "Run Python Tests Lint Checks",
     "Run Python Tests Lockfile Check",


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the "Run CodeLimit" task from the default branch protection modules across multiple Terraform configuration files. The change simplifies the branch protection rules by eliminating this specific task, which is no longer required.

Removal of "Run CodeLimit" task:

* [`stack/DependabotTrigger.tf`](diffhunk://#diff-b8a57b2da236fd1ca2ca395e71438ecc3f420e5f8f55317e5ae636a4091f30a2L62): Removed "Run CodeLimit" from the default branch protection module `DependabotTrigger_default_branch_protection`.
* [`stack/SlocCount.tf`](diffhunk://#diff-d739447262e9ffe0d94173aa0fbecf900d26abd606d622fa121f67b5cbc87936L68): Removed "Run CodeLimit" from the default branch protection module `SlocCount_default_branch_protection`.
* [`stack/aws-timing-scripts.tf`](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceL52): Removed "Run CodeLimit" from the default branch protection module `aws-timing-scripts_default_branch_protection`.
* [`stack/github-stats-analyser.tf`](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bL58): Removed "Run CodeLimit" from the default branch protection module `github-stats-analyser_default_branch_protection`.
* [`stack/github-stats.tf`](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1L68): Removed "Run CodeLimit" from the default branch protection module `github-stats_default_branch_protection`.

Additional files with similar changes:

* [`stack/project-links.tf`](diffhunk://#diff-8d4a200df5e9c4325ae12ffba43bb709aed7403c35680e7b6b89e058fa1f37aeL70): Removed "Run CodeLimit" from the default branch protection module `project-links_default_branch_protection`.
* [`stack/project-status-checker.tf`](diffhunk://#diff-2a4b5a746b5b79e9a3d33092afd952c2b24b3362b4204558c86fd6b917efe8dfL59): Removed "Run CodeLimit" from the default branch protection module `project-status-checker_default_branch_protection`.
* [`stack/repo-overseer.tf`](diffhunk://#diff-83b44e78de7c37d798c938495c4a000f8a5cb8a25c8bb4f687ca44b583a68d4aL68): Removed "Run CodeLimit" from the default branch protection module `repo-overseer_default_branch_protection`.
* [`stack/repo_standards_validator.tf`](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cL57): Removed "Run CodeLimit" from the default branch protection module `repo_standards_validator_default_branch_protection`.
* [`stack/screenshot_mailinator_email.tf`](diffhunk://#diff-9a9d85335e669478ae9ba161a18f43bd7ae0766645d8506de4ef0aed75e6197eL55): Removed "Run CodeLimit" from the default branch protection module `screenshot_mailinator_email_default_branch_protection`.
* [`stack/source_scan.tf`](diffhunk://#diff-4b3bf164059b483435d7002f084e05adc33a2a964754f30a5ebc79fa8489ee26L67): Removed "Run CodeLimit" from the default branch protection module `source_scan_default_branch_protection`.
* [`stack/status-sentinel.tf`](diffhunk://#diff-0a754bed0bccffa46d2be5cda18d1855448c8dc58b211c3dfc8ebec894f2569fL68): Removed "Run CodeLimit" from the default branch protection module `status-sentinel_default_branch_protection`.