### PR TITLE
Update `reusable-workflows` status checks

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -48,10 +48,12 @@ module "reusable-workflows_default_branch_protection" {
   required_status_checks = [
     "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
+    "Common Code Checks / Check GitHub Actions with Actionlint",
     "Common Code Checks / Check GitHub Actions with zizmor",
     "Common Code Checks / Check Justfile Format",
     "Common Code Checks / Check Markdown links",
     "Common Code Checks / Lefthook Validate",
+    "Common Code Checks / Pinact Check",
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection settings in `stack/reusable-workflows.tf` to include additional required status checks for improved code quality and workflow validation.

Branch protection updates:

* [`stack/reusable-workflows.tf`](diffhunk://#diff-7798ff67e4824cab3b5573524834853721910d9747a8e41a30fa895206636e86R51-R56): Added "Common Code Checks / Check GitHub Actions with Actionlint" and "Common Code Checks / Pinact Check" to the `required_status_checks` list to ensure stricter validation of GitHub Actions and pinned dependencies.
