### PR TITLE
Add gitdash repository

### DIFF
--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -28,4 +28,10 @@ resource "github_repository" "gitdash" {
       status = "enabled"
     }
   }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new Terraform resource configuration for a GitHub repository named `gitdash`. The configuration includes settings for pull request management, security features, and repository templates.

### Repository configuration:

* [`stack/gitdash.tf`](diffhunk://#diff-76d8e384d182a12daccec99ce3f419bfeea54c8a9a6fe740748a0b64989ecb2bR1-R37): Added a new `github_repository` resource named `gitdash` with public visibility and pull request settings such as enabling auto-merge, disallowing merge and rebase commits, and enforcing branch deletion after merge.

### Security enhancements:

* [`stack/gitdash.tf`](diffhunk://#diff-76d8e384d182a12daccec99ce3f419bfeea54c8a9a6fe740748a0b64989ecb2bR1-R37): Enabled `secret_scanning` and `secret_scanning_push_protection` under the `security_and_analysis` block to enhance repository security.

### Template settings:

* [`stack/gitdash.tf`](diffhunk://#diff-76d8e384d182a12daccec99ce3f419bfeea54c8a9a6fe740748a0b64989ecb2bR1-R37): Configured the repository to use a template with `owner` set to "JackPlowman" and `repository` set to "repository-template".
