### PR TITLE
Add Dependabot Security Updates for gitdash

### DIFF
--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -35,3 +35,8 @@ resource "github_repository" "gitdash" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "gitdash" {
+  repository = github_repository.gitdash.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new resource to enable Dependabot security updates for the `gitdash` repository in the Terraform configuration.

* [`stack/gitdash.tf`](diffhunk://#diff-76d8e384d182a12daccec99ce3f419bfeea54c8a9a6fe740748a0b64989ecb2bR38-R42): Added the `github_repository_dependabot_security_updates` resource to ensure Dependabot security updates are enabled for the `gitdash` repository.