### PR TITLE
Add gitdash status checks

### DIFF
--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -40,3 +40,24 @@ resource "github_repository_dependabot_security_updates" "gitdash" {
   repository = github_repository.gitdash.name
   enabled    = true
 }
+
+module "gitdash_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.gitdash.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis (actions) / Analyse code",
+    "Common Code Checks / Check GitHub Actions with Actionlint",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Lefthook Validate",
+    "Common Code Checks / Pinact Check",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.gitdash]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module for default branch protection in the `gitdash` repository. The module enforces specific status checks and code scanning tools to ensure higher code quality and security.

### Addition of Default Branch Protection:
* **New module `gitdash_default_branch_protection`:** Added a module sourced from `../modules/default-branch-protection` to enforce branch protection rules for the `gitdash` repository. It includes required status checks such as code quality analysis, dependency review, and validation tasks, as well as mandatory code scanning tools (`zizmor` and `CodeQL`).