### PR TITLE
Update Lefthook Minimum Version

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.14
+min_version: 1.12.2
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the minimum version requirement for Lefthook in the `lefthook.yml` configuration file. 

* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL2-R2): Updated `min_version` from `1.11.14` to `1.12.2` to ensure compatibility with newer features or fixes.