### PR TITLE
Add one-time-scripts repository

### DIFF
--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -1,0 +1,41 @@
+resource "github_repository" "one-time-scripts" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name        = "one-time-scripts"
+  description = ""
+  visibility  = "public"
+
+  # Repository Features
+  has_issues   = true
+  has_projects = true
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub repository resource definition in the Terraform configuration file `stack/one-time-scripts.tf`. The resource is configured with specific repository settings, security features, and a template for initialization.

### Addition of a new GitHub repository resource:

* **Resource definition**: Added a new `github_repository` resource named `one-time-scripts` with public visibility and several repository features enabled, such as issues and projects.

* **Pull request settings**: Configured pull request behavior, including enabling auto-merge, requiring branch updates, and setting squash merge options for commit messages and titles.

* **Security settings**: Enabled secret scanning and push protection for enhanced security.

* **Template configuration**: Configured the repository to use a template from the `JackPlowman/repository-template` repository, excluding all branches except the default one.