### PR TITLE
Add one-time-scripts repository description

### DIFF
--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -2,7 +2,7 @@ resource "github_repository" "one-time-scripts" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name        = "one-time-scripts"
-  description = ""
+  description = "My collection of one-time scripts for various administrative or setup tasks."
   visibility  = "public"
 
   # Repository Features


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the description of the `github_repository` resource in the `stack/one-time-scripts.tf` file to provide more context about its purpose.

* [`stack/one-time-scripts.tf`](diffhunk://#diff-733a6e243efcbc1af27a33f578f69dd9c5fabef1ec3e397783116cfbccdc48afL5-R5): Updated the `description` field of the `github_repository` resource to describe it as "My collection of one-time scripts for various administrative or setup tasks," replacing the previous empty string.