### PR TITLE
Add one-time-scripts dependabot security updates

### DIFF
--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -39,3 +39,8 @@ resource "github_repository" "one-time-scripts" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "one-time-scripts" {
+  repository = github_repository.one-time-scripts.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new resource to enable Dependabot security updates for the `one-time-scripts` repository in the Terraform configuration.

* **Enhancing repository security**:
  * Added a new `github_repository_dependabot_security_updates` resource to enable Dependabot security updates for the `one-time-scripts` repository. This ensures that the repository automatically receives security updates for its dependencies. (`stack/one-time-scripts.tf`, [stack/one-time-scripts.tfR42-R46](diffhunk://#diff-733a6e243efcbc1af27a33f578f69dd9c5fabef1ec3e397783116cfbccdc48afR42-R46))