### PR TITLE
Add one time scripts status checks

### DIFF
--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -44,3 +44,27 @@ resource "github_repository_dependabot_security_updates" "one-time-scripts" {
   repository = github_repository.one-time-scripts.name
   enabled    = true
 }
+
+module "one-time-scripts_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.one-time-scripts.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis (actions) / Analyse code",
+    "Common Code Checks / Check GitHub Actions with Actionlint",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Check for Secrets with Gitleaks",
+    "Common Code Checks / Check for Secrets with TruffleHog",
+    "Common Code Checks / Check for Vulnerabilities with Grype",
+    "Common Code Checks / Lefthook Validate",
+    "Common Code Checks / Pinact Check",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.one-time-scripts]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module to enforce default branch protection settings for the `one-time-scripts` repository. The most significant change is the addition of the `one-time-scripts_default_branch_protection` module, which specifies required status checks and code scanning tools for branch protection.

### Branch Protection Enhancements:

* **Added branch protection module**: Introduced the `module "one-time-scripts_default_branch_protection"` in `stack/one-time-scripts.tf` to enforce default branch protection for the `one-time-scripts` repository. This includes specifying required status checks such as "Check Code Quality" and "CodeQL Analysis," as well as required code scanning tools like "zizmor" and "CodeQL."