### PR TITLE
Add dev-cli repository

### DIFF
--- a/modules/default-branch-protection/version.tf
+++ b/modules/default-branch-protection/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.2"
+  required_version = "1.10.3"
   required_providers {
     github = {
       source  = "integrations/github"

--- a/stack/dev-cli.tf
+++ b/stack/dev-cli.tf
@@ -1,0 +1,37 @@
+resource "github_repository" "dev-cli" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name        = "dev-cli"
+  description = ""
+  visibility  = "public"
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
+}

--- a/stack/terraform.tf
+++ b/stack/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.2"
+  required_version = "1.10.3"
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to Terraform configurations and the addition of a new GitHub repository resource. The most significant changes involve upgrading the required Terraform version and adding detailed configuration for a new repository named `dev-cli`.

### Terraform version updates:
* Updated the `required_version` from `1.10.2` to `1.10.3` in `modules/default-branch-protection/version.tf` and `stack/terraform.tf` to ensure compatibility with the latest Terraform features. [[1]](diffhunk://#diff-083dcdd2848fb453f0966cc360d8160b73b9759560863e07dc0e7ae21f851b8aL2-R2) [[2]](diffhunk://#diff-071e1b4d3f4377396546dc5bc41672a414c0723beedc4b4ed2a37a2c5086ccf5L2-R2)

### New GitHub repository resource:
* Added a new `github_repository` resource for `dev-cli` in `stack/dev-cli.tf`. This includes settings for pull request behavior, security configurations (e.g., secret scanning and push protection), and repository template usage.