### PR TITLE
Add dev-cli dependabot security updates

### DIFF
--- a/stack/dev-cli.tf
+++ b/stack/dev-cli.tf
@@ -35,3 +35,8 @@ resource "github_repository" "dev-cli" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "dev-cli" {
+  repository = github_repository.dev-cli.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new feature to enable Dependabot security updates for the `dev-cli` repository in the Terraform configuration.

Key change:

* [`stack/dev-cli.tf`](diffhunk://#diff-60c3e5884ff87fbb7d5eca175f44f05b40fb87dcf1d874a66746ab9a24eac8f0R38-R42): Added a new `github_repository_dependabot_security_updates` resource to enable Dependabot security updates for the `dev-cli` repository.