### PR TITLE
Add dev-cli status checks

### DIFF
--- a/stack/dev-cli.tf
+++ b/stack/dev-cli.tf
@@ -40,3 +40,27 @@ resource "github_repository_dependabot_security_updates" "dev-cli" {
   repository = github_repository.dev-cli.name
   enabled    = true
 }
+
+module "dev-cli_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.dev-cli.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis (actions) / Analyse code",
+    "Common Code Checks / Check GitHub Actions with Actionlint",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Check for Secrets with Gitleaks",
+    "Common Code Checks / Check for Secrets with TruffleHog",
+    "Common Code Checks / Check for Vulnerabilities with Grype",
+    "Common Code Checks / Lefthook Validate",
+    "Common Code Checks / Pinact Check",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL"]
+
+  depends_on = [github_repository.dev-cli]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module for default branch protection in the `dev-cli` repository. The changes enhance repository security and enforce consistent quality checks by defining required status checks and code scanning tools.

### Repository security and quality checks:

* Added a `module "dev-cli_default_branch_protection"` to the `stack/dev-cli.tf` file. This module enforces default branch protection for the `dev-cli` repository by specifying required status checks (e.g., "Check Code Quality," "CodeQL Analysis") and code scanning tools ("zizmor" and "CodeQL"). It also establishes a dependency on the `github_repository.dev-cli` resource.