### PR TITLE
Rename dev-cli to dx-cli

### DIFF
--- a/stack/dx-cli.tf
+++ b/stack/dx-cli.tf
@@ -1,7 +1,7 @@
-resource "github_repository" "dev-cli" {
+resource "github_repository" "dx-cli" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
-  name        = "dev-cli"
+  name        = "dx-cli"
   description = "My collection of development command-line tools and scripts"
   visibility  = "public"
 
@@ -36,15 +36,15 @@ resource "github_repository" "dev-cli" {
   }
 }
 
-resource "github_repository_dependabot_security_updates" "dev-cli" {
-  repository = github_repository.dev-cli.name
+resource "github_repository_dependabot_security_updates" "dx-cli" {
+  repository = github_repository.dx-cli.name
   enabled    = true
 }
 
-module "dev-cli_default_branch_protection" {
+module "dx-cli_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
-  repository_name = github_repository.dev-cli.name
+  repository_name = github_repository.dx-cli.name
   required_status_checks = [
     "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
@@ -62,5 +62,5 @@ module "dev-cli_default_branch_protection" {
   ]
   required_code_scanning_tools = ["zizmor", "CodeQL"]
 
-  depends_on = [github_repository.dev-cli]
+  depends_on = [github_repository.dx-cli]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request renames the Terraform configuration for a GitHub repository from `dev-cli` to `dx-cli` and updates all references accordingly. The changes ensure consistency in naming and maintain functionality for the repository's configuration.

### File renaming and resource updates:

* Renamed the file `stack/dev-cli.tf` to `stack/dx-cli.tf` and updated the resource name from `github_repository.dev-cli` to `github_repository.dx-cli`. This includes changing the `name` attribute of the repository from `dev-cli` to `dx-cli`.

### Updates to associated resources and modules:

* Updated the `github_repository_dependabot_security_updates` resource to reflect the new repository name (`dx-cli`) in both its declaration and the `repository` attribute.
* Updated the `module "default_branch_protection"` configuration to use the new repository name (`dx-cli`) in the `repository_name` and `depends_on` attributes.