### PR TITLE
Improve plan performance

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@ tofu-init:
 
 # Plan the tofu stack
 tofu-plan:
-    cd stack && tofu plan
+    cd stack && tofu plan -parallelism 30
 
 # Apply the tofu stack
 tofu-apply:


### PR DESCRIPTION
# Pull Request

## Description

This pull request modifies the `tofu-plan` command in the `Justfile` to improve performance by increasing the parallelism level during the planning phase.

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL11-R11): Updated the `tofu-plan` command to include the `-parallelism 30` flag, which increases the parallelism level for the `tofu plan` operation, potentially speeding up the planning process.