### PR TITLE
Improve parallelism

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,17 +2,19 @@
 # Tofu
 # ------------------------------------------------------------------------------
 
+export tofu_parallelism := "30"
+
 # Initialize the tofu stack
 tofu-init:
     cd stack && tofu init
 
 # Plan the tofu stack
 tofu-plan:
-    cd stack && tofu plan -parallelism 30
+    cd stack && tofu plan -parallelism ${tofu_parallelism}
 
 # Apply the tofu stack
 tofu-apply:
-    cd stack && tofu apply -parallelism 30
+    cd stack && tofu apply -parallelism ${tofu_parallelism}
 
 # Format the tofu code
 tofu-fmt:


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a small but significant improvement to the `Justfile` by introducing a configurable `tofu_parallelism` variable to replace hardcoded values, improving maintainability and flexibility.

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR5-R17): Added an exported `tofu_parallelism` variable and replaced the hardcoded parallelism value (`30`) in the `tofu-plan` and `tofu-apply` recipes with `${tofu_parallelism}`.
