### PR TITLE
Add Grype Code Scanning Tool

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -70,7 +70,7 @@ module "DependabotTrigger_default_branch_protection" {
     "Run Python Lockfile Check",
     "Run Python Type Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "Grype"]
 
   depends_on = [github_repository.DependabotTrigger]
 }

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -54,7 +54,7 @@ module "RepoOrchestrator_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.RepoOrchestrator]
 }

--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -54,7 +54,7 @@ module "RepoSync_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.RepoSync]
 }

--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -81,7 +81,7 @@ module "SlocCount_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "SonarCloud"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "SonarCloud", "Grype"]
 
   depends_on = [github_repository.SlocCount]
 }

--- a/stack/TechInsight.tf
+++ b/stack/TechInsight.tf
@@ -65,7 +65,7 @@ module "TechInsight_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
 
   depends_on = [github_repository.TechInsight]
 }

--- a/stack/TechScanner.tf
+++ b/stack/TechScanner.tf
@@ -64,7 +64,7 @@ module "TechScanner_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
 
   depends_on = [github_repository.TechScanner]
 }

--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -67,7 +67,7 @@ module "actions-status_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.actions-status]
 }

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -59,7 +59,7 @@ module "aws-timing-scripts_default_branch_protection" {
     "Run Python Lint Checks",
     "Run Python Type Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "Grype"]
 
   depends_on = [github_repository.aws-timing-scripts]
 }

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -54,7 +54,7 @@ module "create-repository-tasks_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.create-repository-tasks]
 }

--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -54,7 +54,7 @@ module "development-environment_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.development-environment]
 }

--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -64,7 +64,7 @@ module "development-ideas_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.development-ideas]
 }

--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -61,7 +61,7 @@ module "gitdash_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.gitdash]
 }

--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -64,7 +64,7 @@ module "github-pr-analyser_default_branch_protection" {
     "Run Local Action",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.github-pr-analyser]
 }

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -70,7 +70,7 @@ module "github-stats-analyser_default_branch_protection" {
     "Test GitHub Summary",
     "Validate Schema",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "SonarCloud"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "SonarCloud", "Grype"]
 
   depends_on = [github_repository.github-stats-analyser]
 }

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -77,7 +77,7 @@ module "github-stats_default_branch_protection" {
     "Run TypeScript Code Checks",
     "Test TypeScript Code",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "SonarCloud"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "SonarCloud", "Grype"]
 
   depends_on = [github_repository.github-stats]
 }

--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -64,7 +64,7 @@ module "one-time-scripts_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.one-time-scripts]
 }

--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -78,7 +78,7 @@ module "project-links_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "Grype"]
 
   depends_on = [github_repository.project-links]
 }

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -65,7 +65,7 @@ module "project-status-checker_default_branch_protection" {
     "Run Unit Tests",
     "Test GitHub Summary",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud"]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud", "Grype"]
 
   depends_on = [github_repository.project-status-checker]
 }

--- a/stack/projects.tf
+++ b/stack/projects.tf
@@ -64,7 +64,7 @@ module "projects_default_branch_protection" {
     "Run Python Lint Checks",
     "Run Python Type Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.projects]
 }

--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -64,7 +64,7 @@ module "python-practise_default_branch_protection" {
     "Run Python Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "SonarCloud", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "SonarCloud", "zizmor", "Grype"]
 
   depends_on = [github_repository.python-practise]
 }

--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -76,7 +76,7 @@ module "repo-overseer_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "Grype"]
 
   depends_on = [github_repository.repo-overseer]
 }

--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -68,7 +68,7 @@ module "repo_standards_validator_default_branch_protection" {
     "Run Unit Tests",
     "Validate Schema",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud"]
+  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud", "Grype"]
 
   depends_on = [github_repository.repo_standards_validator]
 }

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -55,7 +55,7 @@ module "repository-template_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.repository-template]
 }

--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -66,7 +66,7 @@ module "repository-visualiser_default_branch_protection" {
     "Common Pull Request Tasks / Label Pull Request",
     "Repository Visualiser",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.repository-template]
 }

--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -60,7 +60,7 @@ module "reusable-workflows_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor"]
+  required_code_scanning_tools = ["zizmor", "Grype"]
 
   depends_on = [github_repository.reusable-workflows]
 }

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -64,7 +64,7 @@ module "screenshot_mailinator_email_default_branch_protection" {
     "Run Python Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor", "Grype"]
 
   depends_on = [github_repository.screenshot_mailinator_email]
 }

--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -76,7 +76,7 @@ module "source_scan_default_branch_protection" {
     "Run Python Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor", "Grype"]
 
   depends_on = [github_repository.source_scan]
 }

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -76,7 +76,7 @@ module "status-sentinel_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "ruff", "ESLint"]
+  required_code_scanning_tools = ["CodeQL", "zizmor", "ruff", "ESLint", "Grype"]
 
   depends_on = [github_repository.status-sentinel]
 }

--- a/stack/tech-radar.tf
+++ b/stack/tech-radar.tf
@@ -73,7 +73,7 @@ module "tech-radar_default_branch_protection" {
     "Run Python Tests Type Checks",
     "SonarCloud Scan",
   ]
-  required_code_scanning_tools = ["SonarCloud", "zizmor", "CodeQL", "Ruff"]
+  required_code_scanning_tools = ["SonarCloud", "zizmor", "CodeQL", "Ruff", "Grype"]
 
   depends_on = [github_repository.tech-radar]
 }

--- a/stack/travel-map.tf
+++ b/stack/travel-map.tf
@@ -77,7 +77,7 @@ module "travel-map_default_branch_protection" {
     "Run JavaScript Format Checks",
     "Run JavaScript Lint Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 
   depends_on = [github_repository.travel-map]
 }

--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -43,7 +43,7 @@ module "useful-commands_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
 
   depends_on = [github_repository.useful-commands]
 }

--- a/stack/windows-development-environment.tf
+++ b/stack/windows-development-environment.tf
@@ -50,7 +50,7 @@ module "windows-development-environment_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor"]
+  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
 
   depends_on = [github_repository.windows-development-environment]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds the `Grype` code scanning tool to the `required_code_scanning_tools` list for multiple modules across various Terraform files, enhancing the security checks for default branch protections. The changes ensure consistent integration of `Grype` alongside existing tools like `zizmor`, `CodeQL`, and others.

### Security Enhancements:
* Added `Grype` to the `required_code_scanning_tools` list in the following modules:
  - `DependabotTrigger` in `stack/DependabotTrigger.tf`
  - `RepoOrchestrator` in `stack/RepoOrchestrator.tf`
  - `RepoSync` in `stack/RepoSync.tf`
  - `SlocCount` in `stack/SlocCount.tf`
  - `TechInsight` in `stack/TechInsight.tf`
  - `TechScanner` in `stack/TechScanner.tf`
  - `actions-status` in `stack/actions-status.tf`
  - `aws-timing-scripts` in `stack/aws-timing-scripts.tf`
  - `create-repository-tasks` in `stack/create-repository-tasks.tf`
  - `development-environment` in `stack/development-environment.tf`
  - `development-ideas` in `stack/development-ideas.tf`
  - `gitdash` in `stack/gitdash.tf`
  - `github-pr-analyser` in `stack/github-pr-analyser.tf`
  - `github-stats-analyser` in `stack/github-stats-analyser.tf`
  - `github-stats` in `stack/github-stats.tf`
  - `one-time-scripts` in `stack/one-time-scripts.tf`
  - `project-links` in `stack/project-links.tf`
  - `project-status-checker` in `stack/project-status-checker.tf`
  - `projects` in `stack/projects.tf`
  - `python-practise` in `stack/python-practise.tf`
