### PR TITLE
Bump Tofu version to 1.10.5

### DIFF
--- a/modules/default-branch-protection/version.tf
+++ b/modules/default-branch-protection/version.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = "1.10.3"
+  required_version = "1.10.5"
+
   required_providers {
     github = {
       source  = "integrations/github"

--- a/stack/terraform.tf
+++ b/stack/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.3"
+  required_version = "1.10.5"
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required Terraform version across multiple files to ensure compatibility with newer features or fixes.

Version updates:
* Updated `required_version` in `modules/default-branch-protection/version.tf` from `1.10.3` to `1.10.5`.
* Updated `required_version` in `stack/terraform.tf` from `1.10.3` to `1.10.5`.