### PR TITLE
Add exercism status checks

### DIFF
--- a/stack/exercism.tf
+++ b/stack/exercism.tf
@@ -39,3 +39,33 @@ resource "github_repository" "exercism" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "exercism" {
+  repository = github_repository.exercism.name
+  enabled    = true
+}
+
+module "exercism_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.exercism.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis (actions) / Analyse code",
+    "Common Code Checks / Check File Formats with EditorConfig Checker",
+    "Common Code Checks / Check GitHub Actions with Actionlint",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Check for Secrets with Gitleaks",
+    "Common Code Checks / Check for Secrets with TruffleHog",
+    "Common Code Checks / Check for Vulnerabilities with Grype",
+    "Common Code Checks / Lefthook Validate",
+    "Common Code Checks / Pinact Check",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+
+  depends_on = [github_repository.exercism]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces enhancements to the GitHub repository configuration for the `exercism` project, focusing on improving security and enforcing branch protection standards. The key changes include enabling Dependabot security updates and adding a module for default branch protection with specific status checks and code scanning tools.

### Enhancements to repository configuration:

* **Enabled Dependabot security updates**: Added a `github_repository_dependabot_security_updates` resource to automatically enable Dependabot security updates for the `exercism` repository.

* **Default branch protection**: Introduced a `module "exercism_default_branch_protection"` to enforce branch protection rules, including required status checks (e.g., code quality checks, vulnerability scanning, and dependency reviews) and required code scanning tools (`zizmor`, `CodeQL`, and `Grype`). This ensures higher code quality and security standards.