### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -47,7 +47,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,6 +59,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -11,6 +11,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@671deb8527d0e3b1da46cbc87071f5581896e297 # v2025.08.01.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the reusable workflow references in several GitHub Actions workflow files to use a newer version (`v2025.08.04.01`) of the workflows. These updates ensure that the latest improvements and fixes in the reusable workflows are applied.

### Workflow updates:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated the reusable workflow reference for `common-clean-caches.yml` to the latest version.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L50-R50): Updated the reusable workflow references for `common-code-checks.yml` and `codeql-analysis.yml` to the latest version. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L50-R50) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L62-R62)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL14-R14): Updated the reusable workflow reference for `common-pull-request-tasks.yml` to the latest version.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19): Updated the reusable workflow reference for `common-sync-labels.yml` to the latest version.