### PR TITLE
Update remove-pr-bot-collaborators description

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -76,9 +76,8 @@ module "github-stats_default_branch_protection" {
     "Run Python Tests Lockfile Check",
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
-    "Test TypeScript Code",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "SonarCloud", "Grype"]
+  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "Grype"]
 
   depends_on = [github_repository.github-stats]
 }

--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -2,7 +2,7 @@ resource "github_repository" "remove-pr-bot-collaborators" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name        = "remove-pr-bot-collaborators"
-  description = ""
+  description = "A bot to automatically remove collaborators from pull requests"
   visibility  = "public"
 
   # Repository Features


### PR DESCRIPTION
# Pull Request

## Description


This pull request makes small but important updates to repository configuration and metadata. The main changes are a clarification of the repository description for `remove-pr-bot-collaborators` and a minor adjustment to required code scanning tools and status checks for the default branch protection in `github-stats`.

Repository metadata improvement:

* Updated the `description` field for the `remove-pr-bot-collaborators` repository to clearly state its purpose as a bot for automatically removing collaborators from pull requests.

Default branch protection updates:

* Removed the `"Test TypeScript Code"` status check from the required status checks list for the `github-stats` repository.
* Removed `"SonarCloud"` from the list of required code scanning tools for the `github-stats` repository.