### PR TITLE
Add remove-pr-bot-collaborators dependabot security updates

### DIFF
--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -39,3 +39,8 @@ resource "github_repository" "remove-pr-bot-collaborators" {
     repository           = "repository-template"
   }
 }
+
+resource "github_repository_dependabot_security_updates" "remove-pr-bot-collaborators" {
+  repository = github_repository.remove-pr-bot-collaborators.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new resource to enable Dependabot security updates for the `remove-pr-bot-collaborators` repository in the Terraform configuration. This improves automated dependency management and security for the repository.

Dependency management:

* Added `github_repository_dependabot_security_updates` resource to enable Dependabot security updates for the `remove-pr-bot-collaborators` repository in `stack/remove-pr-bot-collaborators.tf`.