### PR TITLE
Add remove-pr-bot-collaborators status checks

### DIFF
--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -44,3 +44,30 @@ resource "github_repository_dependabot_security_updates" "remove-pr-bot-collabor
   repository = github_repository.remove-pr-bot-collaborators.name
   enabled    = true
 }
+
+
+module "remove-pr-bot-collaborators_default_branch_protection" {
+  source = "../modules/default-branch-protection"
+
+  repository_name = github_repository.remove-pr-bot-collaborators.name
+  required_status_checks = [
+    "Check Code Quality",
+    "CodeQL Analysis (actions) / Analyse code",
+    "CodeQL Analysis (javascript) / Analyse code",
+    "Common Code Checks / Check File Formats with EditorConfig Checker",
+    "Common Code Checks / Check GitHub Actions with Actionlint",
+    "Common Code Checks / Check GitHub Actions with zizmor",
+    "Common Code Checks / Check Justfile Format",
+    "Common Code Checks / Check Markdown links",
+    "Common Code Checks / Check for Secrets with Gitleaks",
+    "Common Code Checks / Check for Secrets with TruffleHog",
+    "Common Code Checks / Check for Vulnerabilities with Grype",
+    "Common Code Checks / Lefthook Validate",
+    "Common Code Checks / Pinact Check",
+    "Common Pull Request Tasks / Dependency Review",
+    "Common Pull Request Tasks / Label Pull Request",
+  ]
+  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
+
+  depends_on = [github_repository.remove-pr-bot-collaborators]
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new module to enforce default branch protection for the `remove-pr-bot-collaborators` repository. The main change is the addition of branch protection rules, including required status checks and code scanning tools, to improve repository security and code quality.

Branch protection configuration:

* Added a `module "remove-pr-bot-collaborators_default_branch_protection"` to `stack/remove-pr-bot-collaborators.tf`, specifying a comprehensive set of required status checks and code scanning tools for the default branch.