### PR TITLE
Update Reusable Workflows & GitHub Actions

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@213eae09e5b24b7be8a5ca596be7ea34a7c0989d # v2025.08.11.03
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,7 +23,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -47,7 +47,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@213eae09e5b24b7be8a5ca596be7ea34a7c0989d # v2025.08.11.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,6 +59,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@213eae09e5b24b7be8a5ca596be7ea34a7c0989d # v2025.08.11.03
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -11,6 +11,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@213eae09e5b24b7be8a5ca596be7ea34a7c0989d # v2025.08.11.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@440c19531fe4aaad17688abf374ed722792369c5 # v2025.08.08.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@213eae09e5b24b7be8a5ca596be7ea34a7c0989d # v2025.08.11.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to use newer versions of shared reusable workflows and the `actions/checkout` action. These changes help ensure the latest improvements, bug fixes, and security updates are applied to CI/CD processes.

Workflow version updates:

* Updated references to the shared reusable workflows (`common-clean-caches.yml`, `common-code-checks.yml`, `codeql-analysis.yml`, `common-pull-request-tasks.yml`, and `common-sync-labels.yml`) to use version `213eae09e5b24b7be8a5ca596be7ea34a7c0989d` instead of `440c19531fe4aaad17688abf374ed722792369c5` in `.github/workflows/clean-caches.yml`, `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml`. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L50-R50) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L62-R62) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL14-R14) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19)

Action dependency update:

* Updated the `actions/checkout` step in `.github/workflows/code-checks.yml` to use version `v5.0.0` instead of `v4.2.2`, ensuring compatibility and access to the latest features.