### PR TITLE
Move Common required_code_scanning_tools to local

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -71,7 +71,7 @@ module "DependabotTrigger_default_branch_protection" {
     "Run Python Lockfile Check",
     "Run Python Type Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff"])
 
   depends_on = [github_repository.DependabotTrigger]
 }

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -55,7 +55,7 @@ module "RepoOrchestrator_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.RepoOrchestrator]
 }

--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -56,7 +56,7 @@ module "RepoSync_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.RepoSync]
 }

--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -82,7 +82,7 @@ module "SlocCount_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "SonarCloud", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.SlocCount]
 }

--- a/stack/TechInsight.tf
+++ b/stack/TechInsight.tf
@@ -66,7 +66,7 @@ module "TechInsight_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.TechInsight]
 }

--- a/stack/TechScanner.tf
+++ b/stack/TechScanner.tf
@@ -65,7 +65,7 @@ module "TechScanner_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.TechScanner]
 }

--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -68,7 +68,7 @@ module "actions-status_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.actions-status]
 }

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -60,7 +60,7 @@ module "aws-timing-scripts_default_branch_protection" {
     "Run Python Lint Checks",
     "Run Python Type Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff"])
 
   depends_on = [github_repository.aws-timing-scripts]
 }

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -55,7 +55,7 @@ module "create-repository-tasks_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.create-repository-tasks]
 }

--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -55,7 +55,7 @@ module "development-environment_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.development-environment]
 }

--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -65,7 +65,7 @@ module "development-ideas_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.development-ideas]
 }

--- a/stack/exercism.tf
+++ b/stack/exercism.tf
@@ -65,7 +65,7 @@ module "exercism_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.exercism]
 }

--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -62,7 +62,7 @@ module "gitdash_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.gitdash]
 }

--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -65,7 +65,7 @@ module "github-pr-analyser_default_branch_protection" {
     "Run Local Action",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.github-pr-analyser]
 }

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -71,7 +71,7 @@ module "github-stats-analyser_default_branch_protection" {
     "Test GitHub Summary",
     "Validate Schema",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "SonarCloud", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.github-stats-analyser]
 }

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -77,7 +77,7 @@ module "github-stats_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "ESLint"])
 
   depends_on = [github_repository.github-stats]
 }

--- a/stack/locals.tf
+++ b/stack/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  common_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+}

--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -65,7 +65,7 @@ module "one-time-scripts_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.one-time-scripts]
 }

--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -79,7 +79,7 @@ module "project-links_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Ruff", "ESLint", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "ESLint"])
 
   depends_on = [github_repository.project-links]
 }

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -66,7 +66,7 @@ module "project-status-checker_default_branch_protection" {
     "Run Unit Tests",
     "Test GitHub Summary",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.project-status-checker]
 }

--- a/stack/projects.tf
+++ b/stack/projects.tf
@@ -65,7 +65,7 @@ module "projects_default_branch_protection" {
     "Run Python Lint Checks",
     "Run Python Type Checks",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.projects]
 }

--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -65,7 +65,7 @@ module "python-practise_default_branch_protection" {
     "Run Python Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "SonarCloud", "zizmor", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.python-practise]
 }

--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -67,7 +67,7 @@ module "remove-pr-bot-collaborators_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.remove-pr-bot-collaborators]
 }

--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -78,7 +78,7 @@ module "repo-overseer_default_branch_protection" {
     "Run TypeScript Code Checks",
     "Run TypeScript Format Checks",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "ESLint", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "ESLint"])
 
   depends_on = [github_repository.repo-overseer]
 }

--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -69,7 +69,7 @@ module "repo_standards_validator_default_branch_protection" {
     "Run Unit Tests",
     "Validate Schema",
   ]
-  required_code_scanning_tools = ["CodeQL", "Ruff", "zizmor", "SonarCloud", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.repo_standards_validator]
 }

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -56,7 +56,7 @@ module "repository-template_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.repository-template]
 }

--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -67,7 +67,7 @@ module "repository-visualiser_default_branch_protection" {
     "Common Pull Request Tasks / Label Pull Request",
     "Repository Visualiser",
   ]
-  required_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.repository-template]
 }

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -65,7 +65,7 @@ module "screenshot_mailinator_email_default_branch_protection" {
     "Run Python Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.screenshot_mailinator_email]
 }

--- a/stack/source_scan.tf
+++ b/stack/source_scan.tf
@@ -77,7 +77,7 @@ module "source_scan_default_branch_protection" {
     "Run Python Type Checks",
     "Run Unit Tests",
   ]
-  required_code_scanning_tools = ["CodeQL", "SonarCloud", "Ruff", "zizmor", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.source_scan]
 }

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -77,7 +77,7 @@ module "status-sentinel_default_branch_protection" {
     "Run Python Tests Type Checks",
     "Run TypeScript Code Checks",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "ruff", "ESLint", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "ESLint"])
 
   depends_on = [github_repository.status-sentinel]
 }

--- a/stack/tech-radar.tf
+++ b/stack/tech-radar.tf
@@ -74,7 +74,7 @@ module "tech-radar_default_branch_protection" {
     "Run Python Tests Type Checks",
     "SonarCloud Scan",
   ]
-  required_code_scanning_tools = ["SonarCloud", "zizmor", "CodeQL", "Ruff", "Grype"]
+  required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.tech-radar]
 }

--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -44,7 +44,7 @@ module "useful-commands_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.useful-commands]
 }

--- a/stack/windows-development-environment.tf
+++ b/stack/windows-development-environment.tf
@@ -51,7 +51,7 @@ module "windows-development-environment_default_branch_protection" {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  required_code_scanning_tools = ["CodeQL", "zizmor", "Grype"]
+  required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.windows-development-environment]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how required code scanning tools are specified for default branch protection across multiple Terraform modules. It introduces a new local variable, `common_code_scanning_tools`, to centralize the common tools list, and updates each module to use this variable, reducing duplication and improving maintainability. For modules that require additional tools, the configuration now uses `concat` to append them to the common list.

**Centralization of code scanning tool configuration:**

* Added a new local variable `common_code_scanning_tools` containing `["zizmor", "CodeQL", "Grype"]` in `stack/locals.tf`, which serves as the shared baseline for required code scanning tools.

**Refactoring of module configurations to use the centralized list:**

* Updated the following modules to use `local.common_code_scanning_tools` instead of hardcoding the list:  
  - `RepoOrchestrator_default_branch_protection` (`stack/RepoOrchestrator.tf`)
  - `RepoSync_default_branch_protection` (`stack/RepoSync.tf`)
  - `TechInsight_default_branch_protection` (`stack/TechInsight.tf`)
  - `TechScanner_default_branch_protection` (`stack/TechScanner.tf`)
  - `actions-status_default_branch_protection` (`stack/actions-status.tf`)
  - `create-repository-tasks_default_branch_protection` (`stack/create-repository-tasks.tf`)
  - `development-environment_default_branch_protection` (`stack/development-environment.tf`)
  - `development-ideas_default_branch_protection` (`stack/development-ideas.tf`)
  - `exercism_default_branch_protection` (`stack/exercism.tf`)
  - `gitdash_default_branch_protection` (`stack/gitdash.tf`)
  - `github-pr-analyser_default_branch_protection` (`stack/github-pr-analyser.tf`)
  - `one-time-scripts_default_branch_protection` (`stack/one-time-scripts.tf`)

**Handling of modules with additional scanning tool requirements:**

* For modules that require extra tools (such as `Ruff`, `SonarCloud`, and/or `ESLint`), replaced the hardcoded list with `concat(local.common_code_scanning_tools, [...])`:
  - `DependabotTrigger_default_branch_protection` (`stack/DependabotTrigger.tf`)
  - `aws-timing-scripts_default_branch_protection` (`stack/aws-timing-scripts.tf`)
  - `SlocCount_default_branch_protection` (`stack/SlocCount.tf`)
  - `github-stats-analyser_default_branch_protection` (`stack/github-stats-analyser.tf`)
  - `github-stats_default_branch_protection` (`stack/github-stats.tf`)
  - `project-links_default_branch_protection` (`stack/project-links.tf`)
  - `project-status-checker_default_branch_protection` (`stack/project-status-checker.tf`)