### PR TITLE
Update windows-developement-environment status checks

### DIFF
--- a/stack/windows-development-environment.tf
+++ b/stack/windows-development-environment.tf
@@ -36,7 +36,6 @@ module "windows-development-environment_default_branch_protection" {
 
   repository_name = github_repository.windows-development-environment.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",
     "Common Code Checks / Check GitHub Actions with Actionlint",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the branch protection rules for the Windows development environment. The change removes a required status check from the list of checks that must pass before merging.

* Removed the `"Check Code Quality"` status check from the `required_status_checks` in the `windows-development-environment_default_branch_protection` module in `stack/windows-development-environment.tf`.