### PR TITLE
Update actions-status status checks

### DIFF
--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -50,24 +50,14 @@ module "actions-status_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.actions-status.name
-  required_status_checks = [
-    "Check Code Quality",
-    "Check Pull Request Title",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (typescript) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Pull Request Title",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (typescript) / Analyse code",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.actions-status]


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how required status checks are specified for the `actions-status_default_branch_protection` module. Instead of listing all required status checks explicitly, it now uses the `concat` function to combine a small set of specific checks with a shared list from `local.common_required_status_checks`. This change makes the configuration more maintainable and consistent across repositories.

**Configuration refactoring:**

* The `required_status_checks` argument in `stack/actions-status.tf` is now constructed using `concat`, merging a set of specific checks with the shared `local.common_required_status_checks` list, instead of listing all checks explicitly.