### PR TITLE
Update aws-timing-scripts status checks

### DIFF
--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -48,6 +48,7 @@ module "aws-timing-scripts_default_branch_protection" {
       "Run Python Lint Checks",
       "Run Python Type Checks",
     ],
+    local.common_required_status_checks
   )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff"])
 

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -39,27 +39,16 @@ module "aws-timing-scripts_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.aws-timing-scripts.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Python Dead Code Checks",
-    "Run Python Format Checks",
-    "Run Python Lint Checks",
-    "Run Python Type Checks",
-  ]
+  required_status_checks = concat(
+    [
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "Run Python Dead Code Checks",
+      "Run Python Format Checks",
+      "Run Python Lint Checks",
+      "Run Python Type Checks",
+    ],
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff"])
 
   depends_on = [github_repository.aws-timing-scripts]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the `aws-timing-scripts_default_branch_protection` Terraform module to improve maintainability and consistency. The main change is refactoring the list of required status checks to use a shared local variable, which helps centralize configuration and reduces duplication.

**Refactoring and configuration improvements:**

* The `required_status_checks` list in `stack/aws-timing-scripts.tf` is now built by concatenating a module-specific list with `local.common_required_status_checks`, consolidating common checks in one place for easier updates.