### PR TITLE
Update create-repository-tasks status checks

### DIFF
--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -39,22 +39,14 @@ module "create-repository-tasks_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.create-repository-tasks.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    [
+
+      "CodeQL Analysis (actions) / Analyse code",
+
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.create-repository-tasks]

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -41,9 +41,7 @@ module "create-repository-tasks_default_branch_protection" {
   repository_name = github_repository.create-repository-tasks.name
   required_status_checks = concat(
     [
-
       "CodeQL Analysis (actions) / Analyse code",
-
     ],
     local.common_required_status_checks
   )


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates how required status checks are configured for the `create-repository-tasks_default_branch_protection` Terraform module. The main change is to use the `concat` function to combine a specific list of status checks with a shared set of checks defined in `local.common_required_status_checks`, making the configuration more maintainable and consistent across repositories.

Configuration improvements:

* Updated the `required_status_checks` argument to use `concat`, combining a repository-specific list with `local.common_required_status_checks` for greater flexibility and reuse.