### PR TITLE
Update DependabotTrigger status checks

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -49,28 +49,18 @@ module "DependabotTrigger_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.DependabotTrigger.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Python Dead Code Checks",
-    "Run Python Format Checks",
-    "Run Python Lint Checks",
-    "Run Python Lockfile Check",
-    "Run Python Type Checks",
-  ]
+  required_status_checks = concat(
+    [
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "Run Python Dead Code Checks",
+      "Run Python Format Checks",
+      "Run Python Lint Checks",
+      "Run Python Lockfile Check",
+      "Run Python Type Checks",
+    ],
+    local.common_required_status_checks,
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff"])
 
   depends_on = [github_repository.DependabotTrigger]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection configuration for the `DependabotTrigger` repository. The main change is that the list of required status checks is now composed by combining a repository-specific set with a shared set defined in `local.common_required_status_checks`. This makes the configuration more maintainable and consistent across repositories.

Branch protection configuration improvements:

* Changed the `required_status_checks` in `module "DependabotTrigger_default_branch_protection"` to use `concat()` to combine repository-specific checks with the shared list from `local.common_required_status_checks`, improving maintainability and consistency.