### PR TITLE
Update gitdash status checks

### DIFF
--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -45,23 +45,13 @@ module "gitdash_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.gitdash.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    [
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code"
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.gitdash]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the `gitdash` repository's default branch protection. The main change is to make the list of required status checks more maintainable by combining a static list with the shared checks defined in `local.common_required_status_checks`.

Branch protection configuration improvements:

* The `required_status_checks` argument in the `gitdash_default_branch_protection` module now uses `concat` to combine a static list of two CodeQL checks with the shared checks from `local.common_required_status_checks`, making the configuration more modular and easier to update.