### PR TITLE
Update github-pr-analyser status checks

### DIFF
--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -43,28 +43,18 @@ module "github-pr-analyser_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.github-pr-analyser.name
-  required_status_checks = [
-    "Check Code Quality",
-    "Check Go Format",
-    "Check Pull Request Title",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (go) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Go Vulnerability Check",
-    "Run Local Action",
-    "Run Unit Tests",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Go Format",
+      "Check Pull Request Title",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (go) / Analyse code",
+      "Run Go Vulnerability Check",
+      "Run Local Action",
+      "Run Unit Tests",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.github-pr-analyser]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks configuration for the `github-pr-analyser_default_branch_protection` Terraform module. Instead of listing all required status checks explicitly, it now combines a smaller set of checks with a shared set from `local.common_required_status_checks`, making the configuration more maintainable and consistent across repositories.

**Configuration simplification and maintainability:**

* The `required_status_checks` list in `stack/github-pr-analyser.tf` is now generated by concatenating a reduced set of explicit checks with the shared checks from `local.common_required_status_checks`, reducing duplication and improving maintainability.