### PR TITLE
Update github-stats-analyser status checks

### DIFF
--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -43,34 +43,25 @@ module "github-stats-analyser_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.github-stats-analyser.name
-  required_status_checks = [
-    "Build Docker Image",
-    "Check Code Quality",
-    "Check Pull Request Title",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Local Action",
-    "Run Python Dead Code Checks",
-    "Run Python Format Checks",
-    "Run Python Lint Checks",
-    "Run Python Lockfile Check",
-    "Run Python Type Checks",
-    "Run Unit Tests",
-    "Test GitHub Summary",
-    "Validate Schema",
-  ]
+  required_status_checks = concat(
+    [
+      "Build Docker Image",
+      "Check Pull Request Title",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "CodeQL Analysis (go) / Analyse code",
+      "Run Local Action",
+      "Run Python Dead Code Checks",
+      "Run Python Format Checks",
+      "Run Python Lint Checks",
+      "Run Python Lockfile Check",
+      "Run Python Type Checks",
+      "Run Unit Tests",
+      "Test GitHub Summary",
+      "Validate Schema",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.github-stats-analyser]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection configuration for the `github-stats-analyser` repository in `stack/github-stats-analyser.tf`. The main improvement is the refactoring of required status checks to use a shared list, making the configuration more maintainable and consistent across repositories.

Branch protection configuration improvements:

* Refactored the `required_status_checks` list to use `concat` with a shared variable `local.common_required_status_checks`, reducing duplication and ensuring consistency for status checks across repositories. [[1]](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bL46-R52) [[2]](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bL73-R64)
* Added "CodeQL Analysis (go) / Analyse code" to the explicit list of required status checks, ensuring Go code is analyzed for vulnerabilities.