### PR TITLE
Update github-stats-analyser status checks

### DIFF
--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -49,7 +49,6 @@ module "github-stats-analyser_default_branch_protection" {
       "Check Pull Request Title",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (python) / Analyse code",
-      "CodeQL Analysis (go) / Analyse code",
       "Run Local Action",
       "Run Python Dead Code Checks",
       "Run Python Format Checks",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the default branch protection rules for the `github-stats-analyser` module. The most notable change is the removal of the "CodeQL Analysis (go) / Analyse code" check from the required status checks.

* Removed the "CodeQL Analysis (go) / Analyse code" status check from the list of required checks in the `github-stats-analyser_default_branch_protection` module (`stack/github-stats-analyser.tf`).
