### PR TITLE
Update github-stats status checks

### DIFF
--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -53,30 +53,20 @@ module "github-stats_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.github-stats.name
-  required_status_checks = [
-    "Check Code Quality",
-    "Check Pull Request Title",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "CodeQL Analysis (typescript) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Python Tests Format Checks",
-    "Run Python Tests Lint Checks",
-    "Run Python Tests Lockfile Check",
-    "Run Python Tests Type Checks",
-    "Run TypeScript Code Checks",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Pull Request Title",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "CodeQL Analysis (typescript) / Analyse code",
+      "Run Python Tests Format Checks",
+      "Run Python Tests Lint Checks",
+      "Run Python Tests Lockfile Check",
+      "Run Python Tests Type Checks",
+      "Run TypeScript Code Checks",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "ESLint"])
 
   depends_on = [github_repository.github-stats]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the default branch protection of the `github-stats` repository, improving maintainability by centralizing common checks. The list of required status checks now dynamically includes a shared set from `local.common_required_status_checks` instead of hardcoding all checks.

Branch protection configuration improvements:

* The `required_status_checks` for the `github-stats` repository are now constructed by concatenating a repository-specific list with `local.common_required_status_checks`, reducing duplication and making it easier to maintain shared checks.