### PR TITLE
Update one-time-scripts status checks

### DIFF
--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -49,22 +49,10 @@ module "one-time-scripts_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.one-time-scripts.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    ["CodeQL Analysis (actions) / Analyse code"],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.one-time-scripts]


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how required status checks are specified for the `one-time-scripts_default_branch_protection` Terraform module. Instead of listing all checks explicitly, it now combines a specific check with a shared list of common checks, improving maintainability and consistency.

Branch protection configuration:

* The `required_status_checks` for `one-time-scripts_default_branch_protection` are now set by concatenating the `"CodeQL Analysis (actions) / Analyse code"` check with the shared `local.common_required_status_checks` list, replacing the previous explicit array of checks.