### PR TITLE
Update reusable-workflows status checks

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -46,7 +46,6 @@ module "reusable-workflows_default_branch_protection" {
 
   repository_name = github_repository.reusable-workflows.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",
     "Common Code Checks / Check GitHub Actions with Actionlint",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the branch protection rules for reusable workflows. The change removes a required status check to streamline the workflow checks.

* Removed the `"Check Code Quality"` status check from the `required_status_checks` list in the `reusable-workflows_default_branch_protection` module in `stack/reusable-workflows.tf`.