### PR TITLE
Update reusable-workflows status checks

### DIFF
--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -45,21 +45,11 @@ module "reusable-workflows_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.reusable-workflows.name
-  required_status_checks = [
+  required_status_checks = concat([
     "CodeQL Analysis (actions) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = ["zizmor", "Grype"]
 
   depends_on = [github_repository.reusable-workflows]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates how required status checks are configured for the `reusable-workflows_default_branch_protection` module. Instead of hardcoding all required status checks, it now combines a specific check with a list of common checks, making the configuration more flexible and maintainable.

**Branch protection configuration improvements:**

* The `required_status_checks` parameter now uses `concat()` to combine the `"CodeQL Analysis (actions) / Analyse code"` check with the list in `local.common_required_status_checks`, instead of listing all checks explicitly.