### PR TITLE
Update project-status-checker status checks

### DIFF
--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -43,29 +43,20 @@ module "project-status-checker_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.project-status-checker.name
-  required_status_checks = [
-    "Build Docker Image and Run",
-    "Check Code Quality",
-    "Check Pull Request Title",
-    "Check Python Code Format and Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Local Project Status Checker Action",
-    "Run Unit Tests",
-    "Test GitHub Summary",
-  ]
+  required_status_checks = concat(
+    [
+      "Build Docker Image and Run",
+      "Check Code Quality",
+      "Check Pull Request Title",
+      "Check Python Code Format and Quality",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "Run Local Project Status Checker Action",
+      "Run Unit Tests",
+      "Test GitHub Summary",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.project-status-checker]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for default branch protection in the `project-status-checker` stack. The main change is to simplify the management of required status checks by referencing a shared list, making it easier to maintain and update common checks across repositories.

**Branch protection configuration improvements:**

* The `required_status_checks` list in `project-status-checker.tf` now uses the `concat` function to combine project-specific checks with a shared list from `local.common_required_status_checks`, replacing a hardcoded list of common checks. This makes the configuration more maintainable and consistent across projects.
* The `required_code_scanning_tools` list is now built by concatenating `local.common_code_scanning_tools` with project-specific tools, further standardizing code scanning requirements.