### PR TITLE
Update python-practice status checks

### DIFF
--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -43,28 +43,19 @@ module "python-practise_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.python-practise.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Python Format Checks",
-    "Run Python Lint Checks",
-    "Run Python Lockfile Check",
-    "Run Python Type Checks",
-    "Run Unit Tests",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Code Quality",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "Run Python Format Checks",
+      "Run Python Lint Checks",
+      "Run Python Lockfile Check",
+      "Run Python Type Checks",
+      "Run Unit Tests",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.python-practise]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates how required status checks are configured for the `python-practise` repository's default branch protection in the Terraform stack. The main change is to simplify and centralize the list of required status checks by leveraging a shared local variable.

**Branch protection configuration improvements:**

* The `required_status_checks` list is now built by concatenating repository-specific checks with the shared `local.common_required_status_checks` variable, making it easier to maintain and update common checks across repositories.
* Redundant hardcoded common status checks have been removed from the module configuration, reducing duplication and improving maintainability.