### PR TITLE
Update remove-pr-bot-collaborators status checks

### DIFF
--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -50,23 +50,14 @@ module "remove-pr-bot-collaborators_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.remove-pr-bot-collaborators.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (javascript) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Code Quality",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (javascript) / Analyse code",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.remove-pr-bot-collaborators]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for default branch protection in the `remove-pr-bot-collaborators` stack. The main change is to how required status checks are specified, making the setup more maintainable and consistent by leveraging shared configuration.

**Branch protection configuration improvements:**

* The `required_status_checks` attribute in `stack/remove-pr-bot-collaborators.tf` now uses `concat` to combine a hardcoded list of checks with the shared list from `local.common_required_status_checks`, simplifying maintenance and ensuring consistency across repositories.