### PR TITLE
Update repo_standard_validator status checks

### DIFF
--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -43,32 +43,23 @@ module "repo_standards_validator_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.repo_standards_validator.name
-  required_status_checks = [
-    "Check Code Quality",
-    "Check Pull Request Title",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Local Action",
-    "Run Python Dead Code Checks",
-    "Run Python Format Checks",
-    "Run Python Lint Checks",
-    "Run Python Lockfile Check",
-    "Run Python Type Checks",
-    "Run Unit Tests",
-    "Validate Schema",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Code Quality",
+      "Check Pull Request Title",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "Run Local Action",
+      "Run Python Dead Code Checks",
+      "Run Python Format Checks",
+      "Run Python Lint Checks",
+      "Run Python Lockfile Check",
+      "Run Python Type Checks",
+      "Run Unit Tests",
+      "Validate Schema",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "SonarCloud"])
 
   depends_on = [github_repository.repo_standards_validator]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for default branch protection in the `repo_standards_validator` stack. The main change is to streamline the management of required status checks by combining repository-specific checks with a shared list of common checks, making the configuration more maintainable and consistent.

**Branch protection configuration improvements:**

* Changed the `required_status_checks` in the `repo_standards_validator_default_branch_protection` module to use `concat`, combining explicit checks with `local.common_required_status_checks` for easier maintenance and consistency across repositories. [[1]](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cL46-L62) [[2]](diffhunk://#diff-548828d513e64730f382377eceb7fbebd56ce2ba808b4351d46cfd60b4e7f33cL71-R62)