### PR TITLE
Update RepoOrchestrator status checks

### DIFF
--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -39,22 +39,10 @@ module "RepoOrchestrator_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.RepoOrchestrator.name
-  required_status_checks = [
-    "Check Code Quality",
-    "CodeQL Analysis (actions) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    ["CodeQL Analysis (actions) / Analyse code"],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.RepoOrchestrator]

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -40,9 +40,7 @@ module "create-repository-tasks_default_branch_protection" {
 
   repository_name = github_repository.create-repository-tasks.name
   required_status_checks = concat(
-    [
-      "CodeQL Analysis (actions) / Analyse code",
-    ],
+    ["CodeQL Analysis (actions) / Analyse code"],
     local.common_required_status_checks
   )
   required_code_scanning_tools = local.common_code_scanning_tools


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how required status checks are defined for default branch protection in Terraform modules. The main improvement is the consolidation of common status checks into the `local.common_required_status_checks` variable, reducing duplication and simplifying future updates.

**Branch protection configuration improvements:**

* In `stack/RepoOrchestrator.tf`, the `required_status_checks` list for the `RepoOrchestrator_default_branch_protection` module now uses `concat` to combine `"CodeQL Analysis (actions) / Analyse code"` with `local.common_required_status_checks`, replacing the previous hardcoded list.
* In `stack/create-repository-tasks.tf`, the `required_status_checks` for the `create-repository-tasks_default_branch_protection` module is similarly updated to use `concat` for better maintainability.