### PR TITLE
Add test-coding-metrics repository

### DIFF
--- a/stack/test-coding-metrics.tf
+++ b/stack/test-coding-metrics.tf
@@ -1,0 +1,42 @@
+resource "github_repository" "test-coding-metrics" {
+  #checkov:skip=CKV_GIT_1
+  #checkov:skip=CKV2_GIT_1
+  name        = "test-coding-metrics"
+  description = ""
+  visibility  = "public"
+
+  # Pull Request settings
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+
+  # Security settings
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  template {
+    include_all_branches = false
+    owner                = "JackPlowman"
+    repository           = "repository-template"
+  }
+}
+
+resource "github_repository_dependabot_security_updates" "test-coding-metrics" {
+  repository = github_repository.test-coding-metrics.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces Terraform configuration to provision a new GitHub repository named `test-coding-metrics` with specific settings for security, repository management, and automation. The changes focus on enforcing best practices for pull requests, enabling security features, and setting up Dependabot for automated security updates.

Repository creation and configuration:

* Adds a `github_repository` resource for `test-coding-metrics` with public visibility, disables downloads, and configures pull request settings such as auto-merge, branch deletion on merge, and squash merge commit customization.
* Enables security features including vulnerability alerts, secret scanning, and push protection for secrets.

Automation and template usage:

* Sets up the repository using a template from `JackPlowman/repository-template`, excluding all branches except default.
* Adds a `github_repository_dependabot_security_updates` resource to enable automated security updates via Dependabot for the repository.