### PR TITLE
Remove `Check Code Quality` Jobs

### DIFF
--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -40,7 +40,6 @@ module "RepoSync_default_branch_protection" {
 
   repository_name = github_repository.RepoSync.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "CodeQL Analysis (python) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",

--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -55,7 +55,6 @@ module "SlocCount_default_branch_protection" {
 
   repository_name = github_repository.SlocCount.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "CodeQL Analysis (python) / Analyse code",
     "CodeQL Analysis (typescript) / Analyse code",

--- a/stack/TechInsight.tf
+++ b/stack/TechInsight.tf
@@ -51,7 +51,6 @@ module "TechInsight_default_branch_protection" {
 
   repository_name = github_repository.TechInsight.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",
     "Common Code Checks / Check GitHub Actions with Actionlint",

--- a/stack/TechScanner.tf
+++ b/stack/TechScanner.tf
@@ -50,7 +50,6 @@ module "TechScanner_default_branch_protection" {
 
   repository_name = github_repository.TechScanner.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",
     "Common Code Checks / Check GitHub Actions with Actionlint",

--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -58,7 +58,6 @@ module "project-links_default_branch_protection" {
   repository_name = github_repository.project-links.name
   required_status_checks = concat(
     [
-      "Check Code Quality",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (python) / Analyse code",
       "CodeQL Analysis (typescript) / Analyse code",

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -46,7 +46,6 @@ module "project-status-checker_default_branch_protection" {
   required_status_checks = concat(
     [
       "Build Docker Image and Run",
-      "Check Code Quality",
       "Check Pull Request Title",
       "Check Python Code Format and Quality",
       "CodeQL Analysis (actions) / Analyse code",

--- a/stack/projects.tf
+++ b/stack/projects.tf
@@ -47,7 +47,6 @@ module "projects_default_branch_protection" {
   repository_name = github_repository.projects.name
   required_status_checks = concat(
     [
-      "Check Code Quality",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (python) / Analyse code",
       "Run Python Format Checks",

--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -45,7 +45,6 @@ module "python-practise_default_branch_protection" {
   repository_name = github_repository.python-practise.name
   required_status_checks = concat(
     [
-      "Check Code Quality",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (python) / Analyse code",
       "Run Python Format Checks",

--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -52,7 +52,6 @@ module "remove-pr-bot-collaborators_default_branch_protection" {
   repository_name = github_repository.remove-pr-bot-collaborators.name
   required_status_checks = concat(
     [
-      "Check Code Quality",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (javascript) / Analyse code",
     ],

--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -55,7 +55,6 @@ module "repo-overseer_default_branch_protection" {
   repository_name = github_repository.repo-overseer.name
   required_status_checks = concat(
     [
-      "Check Code Quality",
       "Check Pull Request Title",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (python) / Analyse code",

--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -45,7 +45,6 @@ module "repo_standards_validator_default_branch_protection" {
   repository_name = github_repository.repo_standards_validator.name
   required_status_checks = concat(
     [
-      "Check Code Quality",
       "Check Pull Request Title",
       "CodeQL Analysis (actions) / Analyse code",
       "CodeQL Analysis (python) / Analyse code",

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -41,7 +41,6 @@ module "repository-template_default_branch_protection" {
 
   repository_name = github_repository.repository-template.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",
     "Common Code Checks / Check GitHub Actions with Actionlint",

--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -50,7 +50,6 @@ module "repository-visualiser_default_branch_protection" {
 
   repository_name = github_repository.repository-visualiser.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "CodeQL Analysis (go) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -43,7 +43,6 @@ module "screenshot_mailinator_email_default_branch_protection" {
 
   repository_name = github_repository.screenshot_mailinator_email.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "CodeQL Analysis (python) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -54,7 +54,6 @@ module "status-sentinel_default_branch_protection" {
 
   repository_name = github_repository.status-sentinel.name
   required_status_checks = [
-    "Check Code Quality",
     "Check Pull Request Title",
     "CodeQL Analysis (actions) / Analyse code",
     "CodeQL Analysis (python) / Analyse code",

--- a/stack/tech-radar.tf
+++ b/stack/tech-radar.tf
@@ -54,7 +54,6 @@ module "tech-radar_default_branch_protection" {
 
   repository_name = github_repository.tech-radar.name
   required_status_checks = [
-    "Check Code Quality",
     "CodeQL Analysis (actions) / Analyse code",
     "Common Code Checks / Check File Formats with EditorConfig Checker",
     "Common Code Checks / Check GitHub Actions with Actionlint",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the default branch protection rules across multiple Terraform stack files by removing the `"Check Code Quality"` status check from the `required_status_checks` list for several repositories. This change streamlines the required checks, likely reflecting a shift in quality assurance processes or a consolidation of code quality checks into other workflows.

**Branch protection rule updates:**

* Removed `"Check Code Quality"` from `required_status_checks` for the following repositories:
  - `RepoSync` (`stack/RepoSync.tf`)
  - `SlocCount` (`stack/SlocCount.tf`)
  - `TechInsight` (`stack/TechInsight.tf`)
  - `TechScanner` (`stack/TechScanner.tf`)
  - `project-links` (`stack/project-links.tf`)
  - `project-status-checker` (`stack/project-status-checker.tf`)
  - `projects` (`stack/projects.tf`)
  - `python-practise` (`stack/python-practise.tf`)
  - `remove-pr-bot-collaborators` (`stack/remove-pr-bot-collaborators.tf`)
  - `repo-overseer` (`stack/repo-overseer.tf`)
  - `repo_standards_validator` (`stack/repo_standards_validator.tf`)
  - `repository-template` (`stack/repository-template.tf`)
  - `repository-visualiser` (`stack/repository-visualiser.tf`)
  - `screenshot_mailinator_email` (`stack/screenshot_mailinator_email.tf`)
  - `status-sentinel` (`stack/status-sentinel.tf`)
  - `tech-radar` (`stack/tech-radar.tf`)
