### PR TITLE
Update repository-visualiser status checks

### DIFF
--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -49,23 +49,14 @@ module "repository-visualiser_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.repository-visualiser.name
-  required_status_checks = [
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (go) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Repository Visualiser",
-  ]
+  required_status_checks = concat(
+    [
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (go) / Analyse code",
+      "Repository Visualiser",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.repository-template]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for default branch protection in the `repository-visualiser` stack. The main change is to centralize and simplify the management of required status checks by concatenating a shared list of checks with repository-specific ones.

Branch protection configuration improvements:

* Changed the `required_status_checks` assignment in `stack/repository-visualiser.tf` to use the `concat` function, combining a repository-specific list with the shared `local.common_required_status_checks` variable. This makes it easier to maintain and update common checks across multiple repositories.