### PR TITLE
Update status-sentinel status checks

### DIFF
--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -53,29 +53,20 @@ module "status-sentinel_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.status-sentinel.name
-  required_status_checks = [
-    "Check Pull Request Title",
-    "CodeQL Analysis (actions) / Analyse code",
-    "CodeQL Analysis (python) / Analyse code",
-    "CodeQL Analysis (typescript) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-    "Run Python Tests Format Checks",
-    "Run Python Tests Lint Checks",
-    "Run Python Tests Lockfile Check",
-    "Run Python Tests Type Checks",
-    "Run TypeScript Code Checks",
-  ]
+  required_status_checks = concat(
+    [
+      "Check Pull Request Title",
+      "CodeQL Analysis (actions) / Analyse code",
+      "CodeQL Analysis (python) / Analyse code",
+      "CodeQL Analysis (typescript) / Analyse code",
+      "Run Python Tests Format Checks",
+      "Run Python Tests Lint Checks",
+      "Run Python Tests Lockfile Check",
+      "Run Python Tests Type Checks",
+      "Run TypeScript Code Checks",
+    ],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = concat(local.common_code_scanning_tools, ["Ruff", "ESLint"])
 
   depends_on = [github_repository.status-sentinel]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required status checks for the `status-sentinel_default_branch_protection` module to improve maintainability and consistency by leveraging shared configuration. Instead of listing all required status checks explicitly, it now combines repository-specific checks with a shared set of common checks.

**Branch protection configuration improvements:**

* The `required_status_checks` for the `status-sentinel_default_branch_protection` module now uses the `concat` function to merge repository-specific checks with the shared list in `local.common_required_status_checks`, reducing duplication and making it easier to maintain common checks across multiple repositories.