### PR TITLE
Update TechInsight status checks

### DIFF
--- a/stack/TechInsight.tf
+++ b/stack/TechInsight.tf
@@ -50,21 +50,10 @@ module "TechInsight_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.TechInsight.name
-  required_status_checks = [
-    "CodeQL Analysis (actions) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    ["CodeQL Analysis (actions) / Analyse code"],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.TechInsight]


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how required status checks are configured for the `TechInsight_default_branch_protection` module in the Terraform stack. Instead of listing all status checks explicitly, it now combines a specific check with a shared set of common checks, making the configuration more maintainable and consistent across repositories.

Configuration simplification:

* The `required_status_checks` list in the `TechInsight_default_branch_protection` module is now built by concatenating the `"CodeQL Analysis (actions) / Analyse code"` check with the shared `local.common_required_status_checks` list, instead of listing all checks individually.