### PR TITLE
Update TechScanner status checks

### DIFF
--- a/stack/TechScanner.tf
+++ b/stack/TechScanner.tf
@@ -49,21 +49,10 @@ module "TechScanner_default_branch_protection" {
   source = "../modules/default-branch-protection"
 
   repository_name = github_repository.TechScanner.name
-  required_status_checks = [
-    "CodeQL Analysis (actions) / Analyse code",
-    "Common Code Checks / Check File Formats with EditorConfig Checker",
-    "Common Code Checks / Check GitHub Actions with Actionlint",
-    "Common Code Checks / Check GitHub Actions with zizmor",
-    "Common Code Checks / Check Justfile Format",
-    "Common Code Checks / Check Markdown links",
-    "Common Code Checks / Check for Secrets with Gitleaks",
-    "Common Code Checks / Check for Secrets with TruffleHog",
-    "Common Code Checks / Check for Vulnerabilities with Grype",
-    "Common Code Checks / Lefthook Validate",
-    "Common Code Checks / Pinact Check",
-    "Common Pull Request Tasks / Dependency Review",
-    "Common Pull Request Tasks / Label Pull Request",
-  ]
+  required_status_checks = concat(
+    ["CodeQL Analysis (actions) / Analyse code"],
+    local.common_required_status_checks
+  )
   required_code_scanning_tools = local.common_code_scanning_tools
 
   depends_on = [github_repository.TechScanner]


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how required status checks are specified for the `TechScanner_default_branch_protection` module in `stack/TechScanner.tf`. Instead of listing all status checks explicitly, it now uses a combination of a hardcoded CodeQL check and a shared local variable for common checks, improving maintainability and consistency.

Branch protection configuration:

* Changed the `required_status_checks` assignment to use `concat()` with a single hardcoded CodeQL check and the shared `local.common_required_status_checks` variable, replacing the previous explicit list of checks.