### PR TITLE
Add Software-Development-Notes Repository

### DIFF
--- a/stack/Software-Development-Notes.tf
+++ b/stack/Software-Development-Notes.tf
@@ -1,0 +1,24 @@
+resource "github_repository" "Software-Development-Notes" {
+  #checkov:skip=CKV2_GIT_1
+  name        = "Software-Development-Notes"
+  description = ""
+  visibility  = "private"
+
+  # Pull Request settings
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_update_branch         = true
+  delete_branch_on_merge      = true
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  # Other settings
+  has_downloads               = false
+  vulnerability_alerts        = true
+  web_commit_signoff_required = true
+}
+
+resource "github_repository_dependabot_security_updates" "Software-Development-Notes" {
+  repository = github_repository.Software-Development-Notes.name
+  enabled    = true
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces Terraform configuration to manage the `Software-Development-Notes` GitHub repository, establishing both repository settings and automated security update features.

Repository provisioning and configuration:

* Adds a new `github_repository` resource for `Software-Development-Notes` with private visibility, disables merge and rebase commits, enables branch updates and branch deletion on merge, and configures squash merge commit messages and titles. Additional settings include disabling downloads, enabling vulnerability alerts, and requiring web commit signoff.

Security and automation:

* Enables Dependabot security updates for the repository by adding a `github_repository_dependabot_security_updates` resource, ensuring automated dependency vulnerability management.