### PR TITLE
Add GitHub Workflow Permission Notes

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 env:
   FORCE_COLOR: 1
@@ -20,9 +19,9 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      actions: read
-      pull-requests: write
-      security-events: write
+      actions: read # Allow the workflow to read actions metadata
+      pull-requests: write # Allow the workflow to create and modify pull request comments
+      security-events: write # Allow the workflow to upload analysis results
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +30,7 @@ jobs:
     name: CodeQL Analysis
     permissions:
       contents: read
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     strategy:
       matrix:
         language: [actions]
@@ -43,8 +42,8 @@ jobs:
     name: Checkov Scan
     permissions:
       contents: read
-      security-events: write
-      actions: read #
+      security-events: write # Allow the workflow to upload analysis results
+      actions: read # Allow the workflow to read actions metadata
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Configure Labels
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # Allow the workflow to create and modify pull request labels
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to clarify and document the permissions granted to each job. The changes mainly add explanatory comments to permission settings, making it easier to understand why each permission is needed.

Workflow permissions documentation improvements:

* Added comments to each permission in the `Common Code Checks`, `CodeQL Analysis`, and `Checkov Scan` jobs in `.github/workflows/code-checks.yml`, explaining the purpose of each permission. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L23-R24) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L34-R33) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L46-R46)
* Added a comment to the `pull-requests: write` permission in the `Configure Labels` job in `.github/workflows/sync-labels.yml` to clarify its use.

Minor permission cleanup:

* Removed the unused `packages: read` permission from the top-level permissions in `.github/workflows/code-checks.yml`.