### PR TITLE
Update Terraform Lockfile

### DIFF
--- a/stack/.terraform.lock.hcl
+++ b/stack/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.opentofu.org/integrations/github" {
   version     = "6.6.0"
   constraints = "6.6.0"
   hashes = [
+    "h1:GV6m1zdKNV0ECNhvzj7UoBXQz1Cv2UQa0UZ7Wt4RgTw=",
     "h1:P4SRG4605PvPKASeDu1lW49TTz1cCGsjQ7qbOBgNd6I=",
     "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
     "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the Terraform lock file, specifically for the GitHub provider. The change adds a new hash entry to ensure the integrity and verification of the provider version.

* Added a new hash (`h1:GV6m1zdKNV0ECNhvzj7UoBXQz1Cv2UQa0UZ7Wt4RgTw=`) to the `provider "registry.opentofu.org/integrations/github"` block in `stack/.terraform.lock.hcl` for version verification.