### PR TITLE
Remove Grype as a scanning tool

### DIFF
--- a/stack/locals.tf
+++ b/stack/locals.tf
@@ -17,5 +17,5 @@ locals {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  common_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  common_code_scanning_tools = ["zizmor", "CodeQL"]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the list of code scanning tools in the `stack/locals.tf` file, removing `Grype` from the `common_code_scanning_tools` list..
