### PR TITLE
Re-add Grype as scanning tool

### DIFF
--- a/stack/locals.tf
+++ b/stack/locals.tf
@@ -17,5 +17,5 @@ locals {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  common_code_scanning_tools = ["zizmor", "CodeQL"]
+  common_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the list of code scanning tools used in the `stack/locals.tf` file. The change adds "Grype" to the existing list of common code scanning tools.