### PR TITLE
Lowercase Grype Scanning Tool Name

### DIFF
--- a/stack/locals.tf
+++ b/stack/locals.tf
@@ -17,5 +17,5 @@ locals {
     "Common Pull Request Tasks / Dependency Review",
     "Common Pull Request Tasks / Label Pull Request",
   ]
-  common_code_scanning_tools = ["zizmor", "CodeQL", "Grype"]
+  common_code_scanning_tools = ["zizmor", "CodeQL", "grype"]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the list of common code scanning tools in the `stack/locals.tf` file. The change corrects the capitalization of the tool name "Grype" to "grype" to ensure consistency.

([stack/locals.tfL20-R20](diffhunk://#diff-95483118b72e4bf891e28872f4cceb5c9ba95cd9b2d65c8c43393ab9e52b24d5L20-R20))