### PR TITLE
Remove deprecated attribute

### DIFF
--- a/stack/DependabotTrigger.tf
+++ b/stack/DependabotTrigger.tf
@@ -19,7 +19,6 @@ resource "github_repository" "DependabotTrigger" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/JackPlowman.tf
+++ b/stack/JackPlowman.tf
@@ -15,7 +15,6 @@ resource "github_repository" "JackPlowman" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/RepoOrchestrator.tf
+++ b/stack/RepoOrchestrator.tf
@@ -15,7 +15,6 @@ resource "github_repository" "RepoOrchestrator" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/RepoOrchestratorState.tf
+++ b/stack/RepoOrchestratorState.tf
@@ -13,7 +13,6 @@ resource "github_repository" "RepoOrchestratorState" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 }

--- a/stack/RepoSync.tf
+++ b/stack/RepoSync.tf
@@ -15,7 +15,6 @@ resource "github_repository" "RepoSync" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/SlocCount.tf
+++ b/stack/SlocCount.tf
@@ -20,7 +20,6 @@ resource "github_repository" "SlocCount" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/Software-Development-Notes.tf
+++ b/stack/Software-Development-Notes.tf
@@ -13,7 +13,6 @@ resource "github_repository" "Software-Development-Notes" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 }

--- a/stack/TechInsight.tf
+++ b/stack/TechInsight.tf
@@ -19,7 +19,6 @@ resource "github_repository" "TechInsight" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/TechScanner.tf
+++ b/stack/TechScanner.tf
@@ -19,7 +19,6 @@ resource "github_repository" "TechScanner" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -19,7 +19,6 @@ resource "github_repository" "actions-status" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/aws-timing-scripts.tf
+++ b/stack/aws-timing-scripts.tf
@@ -15,7 +15,6 @@ resource "github_repository" "aws-timing-scripts" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/coding-metrics.tf
+++ b/stack/coding-metrics.tf
@@ -19,7 +19,6 @@ resource "github_repository" "coding-metrics" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/create-repository-tasks.tf
+++ b/stack/create-repository-tasks.tf
@@ -15,7 +15,6 @@ resource "github_repository" "create-repository-tasks" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/development-environment.tf
+++ b/stack/development-environment.tf
@@ -15,7 +15,6 @@ resource "github_repository" "development-environment" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/development-ideas.tf
+++ b/stack/development-ideas.tf
@@ -16,7 +16,6 @@ resource "github_repository" "development-ideas" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/exercism.tf
+++ b/stack/exercism.tf
@@ -19,7 +19,6 @@ resource "github_repository" "exercism" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/gitdash.tf
+++ b/stack/gitdash.tf
@@ -15,7 +15,6 @@ resource "github_repository" "gitdash" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/github-pr-analyser.tf
+++ b/stack/github-pr-analyser.tf
@@ -19,7 +19,6 @@ resource "github_repository" "github-pr-analyser" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/github-stats-analyser.tf
+++ b/stack/github-stats-analyser.tf
@@ -19,7 +19,6 @@ resource "github_repository" "github-stats-analyser" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/github-stats.tf
+++ b/stack/github-stats.tf
@@ -20,7 +20,6 @@ resource "github_repository" "github-stats" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/one-time-scripts.tf
+++ b/stack/one-time-scripts.tf
@@ -19,7 +19,6 @@ resource "github_repository" "one-time-scripts" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/project-links.tf
+++ b/stack/project-links.tf
@@ -16,7 +16,6 @@ resource "github_repository" "project-links" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/project-status-checker.tf
+++ b/stack/project-status-checker.tf
@@ -19,7 +19,6 @@ resource "github_repository" "project-status-checker" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/projects.tf
+++ b/stack/projects.tf
@@ -15,7 +15,6 @@ resource "github_repository" "projects" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/python-practise.tf
+++ b/stack/python-practise.tf
@@ -19,7 +19,6 @@ resource "github_repository" "python-practise" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/remove-pr-bot-collaborators.tf
+++ b/stack/remove-pr-bot-collaborators.tf
@@ -19,7 +19,6 @@ resource "github_repository" "remove-pr-bot-collaborators" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/repo-overseer.tf
+++ b/stack/repo-overseer.tf
@@ -20,7 +20,6 @@ resource "github_repository" "repo-overseer" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/repo_standards_validator.tf
+++ b/stack/repo_standards_validator.tf
@@ -19,7 +19,6 @@ resource "github_repository" "repo_standards_validator" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/repository-template.tf
+++ b/stack/repository-template.tf
@@ -16,7 +16,6 @@ resource "github_repository" "repository-template" {
 
   # Other settings
   is_template                 = true
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/repository-visualiser.tf
+++ b/stack/repository-visualiser.tf
@@ -19,7 +19,6 @@ resource "github_repository" "repository-visualiser" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/reusable-workflows.tf
+++ b/stack/reusable-workflows.tf
@@ -15,7 +15,6 @@ resource "github_repository" "reusable-workflows" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/screenshot_mailinator_email.tf
+++ b/stack/screenshot_mailinator_email.tf
@@ -18,7 +18,6 @@ resource "github_repository" "screenshot_mailinator_email" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/status-sentinel.tf
+++ b/stack/status-sentinel.tf
@@ -20,7 +20,6 @@ resource "github_repository" "status-sentinel" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/tech-radar.tf
+++ b/stack/tech-radar.tf
@@ -20,7 +20,6 @@ resource "github_repository" "tech-radar" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/test-coding-metrics.tf
+++ b/stack/test-coding-metrics.tf
@@ -16,7 +16,6 @@ resource "github_repository" "test-coding-metrics" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/test-project-status-checker.tf
+++ b/stack/test-project-status-checker.tf
@@ -15,7 +15,6 @@ resource "github_repository" "test-project-status-checker" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/travel-map.tf
+++ b/stack/travel-map.tf
@@ -20,7 +20,6 @@ resource "github_repository" "travel-map" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 

--- a/stack/useful-commands.tf
+++ b/stack/useful-commands.tf
@@ -19,7 +19,6 @@ resource "github_repository" "useful-commands" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 }

--- a/stack/windows-development-environment.tf
+++ b/stack/windows-development-environment.tf
@@ -15,7 +15,6 @@ resource "github_repository" "windows-development-environment" {
   squash_merge_commit_title   = "PR_TITLE"
 
   # Other settings
-  has_downloads               = false
   vulnerability_alerts        = true
   web_commit_signoff_required = true
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `has_downloads = false` setting from all `github_repository` Terraform resources across multiple repository configuration files. This change means the default setting for downloads will now be used for all repositories, rather than explicitly disabling downloads.

Repository configuration updates:

* Removed the explicit `has_downloads = false` property from the following Terraform files, so repositories will no longer have downloads explicitly disabled:
  - `DependabotTrigger.tf`, `JackPlowman.tf`, `RepoOrchestrator.tf`, `RepoOrchestratorState.tf`, `RepoSync.tf`, `SlocCount.tf`, `Software-Development-Notes.tf`, `TechInsight.tf`, `TechScanner.tf`, `actions-status.tf`, `aws-timing-scripts.tf`, `coding-metrics.tf`, `create-repository-tasks.tf`, `development-environment.tf`, `development-ideas.tf`, `exercism.tf`, `gitdash.tf`, `github-pr-analyser.tf`, `github-stats-analyser.tf`, `github-stats.tf` [[1]](diffhunk://#diff-b8a57b2da236fd1ca2ca395e71438ecc3f420e5f8f55317e5ae636a4091f30a2L22) [[2]](diffhunk://#diff-64f71461b75090c0c57ebef2293d861e4b4e8b71e819bc079265e5525ab45b4cL18) [[3]](diffhunk://#diff-91f35e38e4fb154b436ffff883598acbcd0280c0516ddbbfa24d768525b9e306L18) [[4]](diffhunk://#diff-547f611809e14b7aeaba133efa6ac141fae7fa97db4380b01c751272014b992bL16) [[5]](diffhunk://#diff-16e2e62e6acef9a31115ad88e1bb79265e26817c8de6b667393d56923559b8beL18) [[6]](diffhunk://#diff-d739447262e9ffe0d94173aa0fbecf900d26abd606d622fa121f67b5cbc87936L23) [[7]](diffhunk://#diff-6d51c5bbf2a3ada3e6e639ad38b5a56fd63f27967b6a00bc9ddddde74c31c4c4L16) [[8]](diffhunk://#diff-faf5f6cc9f44e006bed6d463ef4e320431977b2289bb09d09d88e0c73e12fa47L22) [[9]](diffhunk://#diff-fae63992707915085d850eebc85275322dba657102564ea929f2a4e8f7e0a0a0L22) [[10]](diffhunk://#diff-8bd85a029b91639709afbcaa82f1b76b17e52f673c261899307786a1d68a7ebbL22) [[11]](diffhunk://#diff-34a66fb6f671fea366fe0b87e09ba5e16fe0b5fae92321030aebab0a3f6b38ceL18) [[12]](diffhunk://#diff-71c8e457e72fdca4cb9cfec48f3458908899ba25cb268dd158fc01b745f4801eL22) [[13]](diffhunk://#diff-0c65d623333b07f372a64d80bfdae6e2460a61e8634b185074d2800d1d167ceeL18) [[14]](diffhunk://#diff-00e2788c3b7e75485d7bb7a91b33585cd0412f41347a3c045135761b660ad7a5L18) [[15]](diffhunk://#diff-b235d4ce59faa805849e113c98ed0576b335ba180dbc2db6a06ce02b1beda850L19) [[16]](diffhunk://#diff-26343981b2972f2ac4e3e1baea97aedd540f1d44ae0bce3d51dd486db61dcc8cL22) [[17]](diffhunk://#diff-76d8e384d182a12daccec99ce3f419bfeea54c8a9a6fe740748a0b64989ecb2bL18) [[18]](diffhunk://#diff-432bae1b13646e0510fa8807f1fcf29e9bb903141c00a6f1958c3ae7df2c16f7L22) [[19]](diffhunk://#diff-6438192d0d2f9a19b7011f360684233c9099bc1d66afb48f2c05f23e3f45c25bL22) [[20]](diffhunk://#diff-4c83331edafb5463d9be52eca7c9e213c0868cddd414c2b7d97d4e1559a70ab1L23)