### PR TITLE
Add actions-status repository description

### DIFF
--- a/stack/actions-status.tf
+++ b/stack/actions-status.tf
@@ -2,7 +2,7 @@ resource "github_repository" "actions-status" {
   #checkov:skip=CKV_GIT_1
   #checkov:skip=CKV2_GIT_1
   name        = "actions-status"
-  description = ""
+  description = "Dashboard repository for tracking the health and status of default branch GitHub Actions workflows."
   visibility  = "public"
 
   # Repository Features


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `actions-status` GitHub repository configuration by adding a descriptive summary to the repository.

- Updated the `description` field in `github_repository.actions-status` to clearly indicate that the repository is a dashboard for tracking the health and status of default branch GitHub Actions workflows.