### PR TITLE
Add Update Commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -132,3 +132,29 @@ editorconfig-check:
 # Install git hooks using prek
 install-git-hooks:
     prek install
+
+# ------------------------------------------------------------------------------
+# Prek
+# ------------------------------------------------------------------------------
+
+# Update prek hooks and additional dependencies
+prek-update:
+    just prek-update-hooks
+    just prek-update-additional-dependencies
+
+# Prek update hooks
+prek-update-hooks:
+    prek autoupdate
+
+prek-update-additional-dependencies:
+    uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
+
+# ------------------------------------------------------------------------------
+# Update All Tools
+# ------------------------------------------------------------------------------
+
+# Update all tools
+update:
+    just pinact-update
+    just prek-update
+    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds new commands to the `Justfile` to streamline updating git hooks and related dependencies managed by Prek. The changes introduce grouped update targets for Prek and all tools, making maintenance tasks easier and more consistent.

Prek update commands:

* Added a `prek-update` command that runs both `prek-update-hooks` and `prek-update-additional-dependencies` for updating Prek hooks and dependencies.
* Introduced `prek-update-hooks` to automatically update Prek hooks with `prek autoupdate`.
* Added `prek-update-additional-dependencies` to update additional dependencies using a remote script via `uv run`.

General tool update command:

* Added an `update` command to run updates for Pinact, Prek, and additional dependencies in one step.