### PR TITLE
Update Prek Versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-merge-conflict
         name: Check Merge Conflicts
@@ -20,26 +20,26 @@ repos:
         name: Detect Private Key
         description: Detects private keys that may have been added to the repository
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # frozen: v8.30.1
     hooks:
       - id: gitleaks
         name: Gitleaks - Secret Detection
         description: Scan for secrets using Gitleaks
         language_version: "go1.25"
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
     hooks:
       - id: actionlint
         name: Actionlint
         description: Linter for GitHub Actions workflow files
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: 3.6.0
+    rev: bebfac867564fbd992e5b45379b4b0568d5cb85b # frozen: 3.6.1
     hooks:
       - id: editorconfig-checker
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.22.0
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # frozen: v1.26.1
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.8.1
+          - prettier@3.9.1
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.pre-commit-config.yaml` file to ensure all pre-commit hooks and dependencies are using the latest stable versions, and bumps the minimum required `prek` version. These updates help maintain security, compatibility, and access to the latest features and fixes.

**Tooling and dependency version updates:**

* Increased `minimum_prek_version` to `0.4.0` to require a newer version of the `prek` pre-commit runner.
* Updated the following pre-commit hooks to newer versions:
  * `pre-commit-hooks` to frozen `3e8a870...` (`v6.0.0`)
  * `gitleaks` to frozen `83d9cd6...` (`v8.30.1`)
  * `actionlint` to frozen `914e7df...` (`v1.7.12`)
  * `editorconfig-checker.python` to frozen `bebfac8...` (`3.6.1`)
  * `zizmor-pre-commit` to frozen `e3eebf6...` (`v1.26.1`)
  * `prettier` dependency to `3.9.1`