### PR TITLE
Ignore Checkov Warnings

### DIFF
--- a/stack/RepoOrchestratorState.tf
+++ b/stack/RepoOrchestratorState.tf
@@ -1,5 +1,6 @@
 resource "github_repository" "RepoOrchestratorState" {
   #checkov:skip=CKV2_GIT_1
+  #checkov:skip=CKV_GIT_3
   name        = "RepoOrchestratorState"
   description = "A state repository for the RepoOrchestrator Infrastructure as Code"
   visibility  = "private"

--- a/stack/Software-Development-Notes.tf
+++ b/stack/Software-Development-Notes.tf
@@ -1,5 +1,6 @@
 resource "github_repository" "Software-Development-Notes" {
   #checkov:skip=CKV2_GIT_1
+  #checkov:skip=CKV_GIT_3
   name        = "Software-Development-Notes"
   description = ""
   visibility  = "private"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds an additional Checkov skip directive to two Terraform files that define GitHub repositories. The new directive (`#checkov:skip=CKV_GIT_3`) instructs Checkov to skip a specific security check when scanning these resources.

Security and compliance configuration:

* Added `#checkov:skip=CKV_GIT_3` to the `github_repository` resource in `stack/RepoOrchestratorState.tf` to skip a Checkov security check.
* Added `#checkov:skip=CKV_GIT_3` to the `github_repository` resource in `stack/Software-Development-Notes.tf` to skip a Checkov security check.